### PR TITLE
PS4 support

### DIFF
--- a/USBHost_t36.h
+++ b/USBHost_t36.h
@@ -521,7 +521,7 @@ private:
 	uint16_t in_size;
 	uint16_t out_size;
 	setup_t setup;
-	uint8_t descriptor[256];
+	uint8_t descriptor[512];
 	uint8_t report[64];
 	uint16_t descsize;
 	bool use_report_id;
@@ -745,7 +745,7 @@ public:
 	bool    available() { return joystickEvent; }
 	void    joystickDataClear();
 	uint32_t getButtons() { return buttons; }
-	int	getAxis(uint32_t index) { return (index < 8) ? axis[index] : 0; }
+	int	getAxis(uint32_t index) { return (index < (sizeof(axis)/sizeof(axis[0]))) ? axis[index] : 0; }
 protected:
 	virtual bool claim_collection(Device_t *dev, uint32_t topusage);
 	virtual void hid_input_begin(uint32_t topusage, uint32_t type, int lgmin, int lgmax);
@@ -758,7 +758,7 @@ private:
 	bool anychange = false;
 	volatile bool joystickEvent = false;
 	uint32_t buttons = 0;
-	int16_t axis[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+	int16_t axis[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 };
 
 #endif

--- a/examples/Mouse/Mouse.ino
+++ b/examples/Mouse/Mouse.ino
@@ -52,7 +52,16 @@ void loop()
     Serial.print(joystick1.getAxis(0));
     Serial.print(", Y = ");
     Serial.print(joystick1.getAxis(1));
-
+    Serial.print(", Z = ");
+    Serial.print(joystick1.getAxis(2));
+    Serial.print(", Rz = ");
+    Serial.print(joystick1.getAxis(5));
+    Serial.print(", Rx = ");
+    Serial.print(joystick1.getAxis(3));
+    Serial.print(", Ry = ");
+    Serial.print(joystick1.getAxis(4));
+    Serial.print(", Hat = ");
+    Serial.print(joystick1.getAxis(9));
     Serial.println();
     joystick1.joystickDataClear();
   }

--- a/joystick.cpp
+++ b/joystick.cpp
@@ -68,7 +68,7 @@ void JoystickController::hid_input_data(uint32_t usage, int32_t value)
 				anychange = true;
 			}
 		}
-	} else if (usage_page == 1 && usage >= 0x30 && usage <= 0x37) {
+	} else if (usage_page == 1 && usage >= 0x30 && usage <= 0x39) {
 		// TODO: need scaling of value to consistent API, 16 bit signed?
 		// TODO: many joysticks repeat slider usage.  Detect & map to axes?
 		uint32_t i = usage - 0x30;


### PR DESCRIPTION
Had to increase size of HID report to 512.
Allow HAT to work 10039

Mouse Example prints out Z, Rz, Ry, Rx and Hat values