### PR TITLE
PS3 - Right Joystick does not work

### DIFF
--- a/hid.cpp
+++ b/hid.cpp
@@ -429,7 +429,11 @@ void USBHIDParser::parse(uint16_t type_and_report_id, const uint8_t *data, uint3
 			break;
 		  case 0x08: // Usage (local)
 			if (usage_count < USAGE_LIST_LEN) {
-				usage[usage_count++] = val;
+				// Usages: 0 is reserved 0x1-0x1f is sort of reserved for top level things like
+				// 0x1 - Pointer - A collection... So lets try ignoring these
+				if (val > 0x1f) {
+					usage[usage_count++] = val;
+				}
 			}
 			break;
 		  case 0x18: // Usage Minimum (local)
@@ -477,6 +481,8 @@ void USBHIDParser::parse(uint16_t type_and_report_id, const uint8_t *data, uint3
 				println("       type= ", val, HEX);
 				println("       min=  ", logical_min);
 				println("       max=  ", logical_max);
+				println("       reportcount=", report_count);
+				println("       usage count=", usage_count);
 				driver->hid_input_begin(topusage, val, logical_min, logical_max);
 				println("Input, total bits=", report_count * report_size);
 				if ((val & 2)) {


### PR DESCRIPTION
There is an issue with the extra items added to the report after the main known items.

Problem was HID report descriptor does something like:
Usage Page; Desktop  (01)
Usage: 01  (Pointer)
Count xxx

Problem is the Usage values below 0x20 appear to have some other standard meaning.   Which you can see in
http://www.usb.org/developers/hidpage/Hut1_12v2.pdf

So current fix is to ignore Usage values passed in < 0x20...
Appears to fix PS3 Right joystick