### PR TITLE
Now only optionally force keyboard into boot protocol mode

### DIFF
--- a/USBHost_t36.h
+++ b/USBHost_t36.h
@@ -683,6 +683,13 @@ public:
 	KeyboardController(USBHost &host) { init(); }
 	KeyboardController(USBHost *host) { init(); }
 
+	// need their own versions as both USBDriver and USBHIDInput provide
+	uint16_t idVendor();
+	uint16_t idProduct();
+	const uint8_t *manufacturer();
+	const uint8_t *product();
+	const uint8_t *serialNumber();
+
 	// Some methods are in both public classes so we need to figure out which one to use
 	operator bool() { return (device != nullptr); }
 	// Main boot keyboard functions. 
@@ -704,6 +711,7 @@ public:
 	// Added for extras information.
 	void     attachExtrasPress(void (*f)(uint32_t top, uint16_t code)) { extrasKeyPressedFunction = f; }
 	void     attachExtrasRelease(void (*f)(uint32_t top, uint16_t code)) { extrasKeyReleasedFunction = f; }
+	void	 forceBootProtocol();
 	enum {MAX_KEYS_DOWN=4};
 
 
@@ -750,7 +758,8 @@ private:
 	volatile bool hid_input_data_ = false; 	// did we receive any valid data with report?
 	uint8_t count_keys_down_ = 0;
 	uint16_t keys_down[MAX_KEYS_DOWN];
-
+	bool 	force_boot_protocol;  // User or VID/PID said force boot protocol?
+	bool control_queued;
 };
 
 
@@ -1283,7 +1292,7 @@ private:
 	uint8_t pl2303_v1;		// Which version do we have
 	uint8_t pl2303_v2;
 	uint8_t interface;
-	bool control_queued;
+	bool 	control_queued;	// Is there already a queued control messaged
 	typedef enum { UNKNOWN=0, CDCACM, FTDI, PL2303, CH341, CP210X } sertype_t;
 	sertype_t sertype;
 

--- a/keyboard.cpp
+++ b/keyboard.cpp
@@ -36,12 +36,17 @@ typedef struct {
 	uint8_t charNumlockOn;		// We will assume when num lock is on we have all characters...
 } keycode_numlock_t;
 
+typedef struct {
+	uint16_t	idVendor;		// vendor id of keyboard
+	uint16_t	idProduct;		// product id - 0 implies all of the ones from vendor; 
+} keyboard_force_boot_protocol_t;	// list of products to force into boot protocol
+
 #ifdef M
 #undef M
 #endif
 #define M(n) ((n) & KEYCODE_MASK)
 
-keycode_extra_t keycode_extras[] = {
+static const keycode_extra_t keycode_extras[] = {
 	{M(KEY_ENTER), '\n'},
 	{M(KEY_ESC), 0x1b},
 	{M(KEY_TAB), 0x9 },
@@ -70,7 +75,7 @@ keycode_extra_t keycode_extras[] = {
 };
 
 // Some of these mapped to key + shift.
-keycode_numlock_t keycode_numlock[] = {
+static const keycode_numlock_t keycode_numlock[] = {
 	{M(KEYPAD_SLASH), 	'/', '/'},
 	{M(KEYPAD_ASTERIX), '*', '*'},
 	{M(KEYPAD_MINUS),	'-', '-'},
@@ -89,6 +94,11 @@ keycode_numlock_t keycode_numlock[] = {
 	{M(KEYPAD_PERIOD), 	0x80 | M(KEY_DELETE), '.'}
 };
 
+static const keyboard_force_boot_protocol_t keyboard_forceBootMode[] = {
+	{0x04D9, 0}
+};
+
+
 #define print   USBHost::print_
 #define println USBHost::println_
 
@@ -99,6 +109,7 @@ void KeyboardController::init()
 	contribute_String_Buffers(mystring_bufs, sizeof(mystring_bufs)/sizeof(strbuf_t));
 	driver_ready_for_device(this);
 	USBHIDParser::driver_ready_for_hid_collection(this);
+	force_boot_protocol = false;	// start off assuming not
 }
 
 bool KeyboardController::claim(Device_t *dev, int type, const uint8_t *descriptors, uint32_t len)
@@ -108,6 +119,7 @@ bool KeyboardController::claim(Device_t *dev, int type, const uint8_t *descripto
 	// only claim at interface level
 	if (type != 1) return false;
 	if (len < 9+9+7) return false;
+	print_hexbytes(descriptors, len);
 
 	uint32_t numendpoint = descriptors[4];
 	if (numendpoint < 1) return false;
@@ -139,22 +151,45 @@ bool KeyboardController::claim(Device_t *dev, int type, const uint8_t *descripto
 	datapipe->callback_function = callback;
 	queue_Data_Transfer(datapipe, report, 8, this);
 
-	mk_setup(setup, 0x21, 11, 0, 0, 0); // 11=SET_PROTOCOL  BOOT
+	// see if this device in list of devices that need to be set in
+	// boot protocol mode
+	bool in_forceBoot_mode_list = false;
+	for (uint8_t i = 0; i < sizeof(keyboard_forceBootMode)/sizeof(keyboard_forceBootMode[0]); i++) {
+		if (dev->idVendor == keyboard_forceBootMode[i].idVendor) {
+			if ((dev->idProduct == keyboard_forceBootMode[i].idProduct) ||
+					(keyboard_forceBootMode[i].idProduct == 0)) {
+				in_forceBoot_mode_list = true;
+				break;
+			}
+		}
+	}
+	if (in_forceBoot_mode_list) {
+		println("SET_PROTOCOL Boot");
+		mk_setup(setup, 0x21, 11, 0, 0, 0); // 11=SET_PROTOCOL  BOOT
+	} else {
+		mk_setup(setup, 0x21, 10, 0, 0, 0); // 10=SET_IDLE
+	}
 	queue_Control_Transfer(dev, &setup, NULL, this);
+	control_queued = true;
 	return true;
 }
 
 void KeyboardController::control(const Transfer_t *transfer)
 {
 	println("control callback (keyboard)");
+	control_queued = false;
 	print_hexbytes(transfer->buffer, transfer->length);
 	// To decode hex dump to human readable HID report summary:
 	//   http://eleccelerator.com/usbdescreqparser/
 	uint32_t mesg = transfer->setup.word1;
 	println("  mesg = ", mesg, HEX);
-	if (mesg == 0x001021 && transfer->length == 0) { // SET_PROTOCOL
+	if (mesg == 0x00B21 && transfer->length == 0) { // SET_PROTOCOL
 		mk_setup(setup, 0x21, 10, 0, 0, 0); // 10=SET_IDLE
+		control_queued = true;
 		queue_Control_Transfer(device, &setup, NULL, this);
+	} else if (force_boot_protocol) {
+		forceBootProtocol();	// lets setup to do the boot protocol
+		force_boot_protocol = false;	// turn back off
 	}
 }
 
@@ -163,6 +198,17 @@ void KeyboardController::callback(const Transfer_t *transfer)
 	//println("KeyboardController Callback (static)");
 	if (transfer->driver) {
 		((KeyboardController *)(transfer->driver))->new_data(transfer);
+	}
+}
+
+void KeyboardController::forceBootProtocol()
+{
+	if (device && !control_queued) {
+		mk_setup(setup, 0x21, 11, 0, 0, 0); // 11=SET_PROTOCOL  BOOT
+		control_queued = true;
+		queue_Control_Transfer(device, &setup, NULL, this);		
+	} else {
+		force_boot_protocol = true;	// let system know we want to force this.
 	}
 }
 
@@ -437,3 +483,43 @@ void KeyboardController::hid_input_end()
 		hid_input_begin_ = false;
 	}		
 }
+
+//*****************************************************************************
+// Some simple query functions depend on which interface we are using...
+//*****************************************************************************
+
+uint16_t KeyboardController::idVendor() 
+{
+	if (device != nullptr) return device->idVendor;
+	if (mydevice != nullptr) return mydevice->idVendor;
+	return 0;
+}
+
+uint16_t KeyboardController::idProduct() 
+{
+	if (device != nullptr) return device->idProduct;
+	if (mydevice != nullptr) return mydevice->idProduct;
+	return 0;
+}
+
+const uint8_t *KeyboardController::manufacturer()
+{
+	if ((device != nullptr) && (device->strbuf != nullptr)) return &device->strbuf->buffer[device->strbuf->iStrings[strbuf_t::STR_ID_MAN]];
+	if ((mydevice != nullptr) && (mydevice->strbuf != nullptr)) return &mydevice->strbuf->buffer[mydevice->strbuf->iStrings[strbuf_t::STR_ID_MAN]]; 
+	return nullptr;
+}
+
+const uint8_t *KeyboardController::product()
+{
+	if ((device != nullptr) && (device->strbuf != nullptr)) return &device->strbuf->buffer[device->strbuf->iStrings[strbuf_t::STR_ID_PROD]];
+	if ((mydevice != nullptr) && (mydevice->strbuf != nullptr)) return &mydevice->strbuf->buffer[mydevice->strbuf->iStrings[strbuf_t::STR_ID_PROD]]; 
+	return nullptr;
+}
+
+const uint8_t *KeyboardController::serialNumber()
+{
+	if ((device != nullptr) && (device->strbuf != nullptr)) return &device->strbuf->buffer[device->strbuf->iStrings[strbuf_t::STR_ID_SERIAL]];
+	if ((mydevice != nullptr) && (mydevice->strbuf != nullptr)) return &mydevice->strbuf->buffer[mydevice->strbuf->iStrings[strbuf_t::STR_ID_SERIAL]]; 
+	return nullptr;
+}
+

--- a/keywords.txt
+++ b/keywords.txt
@@ -31,6 +31,7 @@ updateLEDS	KEYWORD2
 numLock	KEYWORD2
 capsLock	KEYWORD2
 scrollLock	KEYWORD2
+forceBootProtocol	KEYWORD2
 
 # MIDIDevice
 getType	KEYWORD2


### PR DESCRIPTION
The first gigabyte fix, was to always force the keyboard into boot protocol mode, which appeared to work well for all of the keyboards I tried.

Unforationally it caused issues with some wireless keyboard/mouse combo packages, including some logitech and some microsoft keyboards.

This version instead, I created a list (currently only one vendor id), of vendor id:product id, that need to be forced into boot mode.  Knowing that if there is one keyboard vendor with this N key rollover feature, there are probably others.  So while this list can be expanded, this requires users to update library.  So added a method forceBootProtocol method to keyboard class that allows the user to try it out without needing to update the library sources.

The mouse test program has example of either setting it before the keyboard is initiated, as well as another way that when a connection is found it asks for the vendor id, and if it is the one of my gigabyte keyboard, it calls the function then.

While doing this I found some of the query functions like idVendor on the keyboard class would not compile as the keyboard object has multiple inheritence and both base classes have this.  So like the joystick objects I added these to the top level function and these functions will direct the calls to the approrpriate places.