### PR TITLE
fixed race condition in midi transmit

### DIFF
--- a/midi.cpp
+++ b/midi.cpp
@@ -300,6 +300,7 @@ void MIDIDeviceBase::write_packed(uint32_t data)
 			// use tx_buffer1
 			tx_buffer1[tx1++] = data;
 			tx1_count = tx1;
+                        __disable_irq();
 			if (tx1 >= tx_max) {
 				queue_Data_Transfer(txpipe, tx_buffer1, tx_max*4, this);
 			} else {
@@ -308,12 +309,14 @@ void MIDIDeviceBase::write_packed(uint32_t data)
 				tx1_count = tx_max;
 				queue_Data_Transfer(txpipe, tx_buffer1, tx_max*4, this);
 			}
+                        __enable_irq();
 			return;
 		}
 		if (tx2 < tx_max) {
 			// use tx_buffer2
 			tx_buffer2[tx2++] = data;
 			tx2_count = tx2;
+                        __disable_irq();
 			if (tx2 >= tx_max) {
 				queue_Data_Transfer(txpipe, tx_buffer2, tx_max*4, this);
 			} else {
@@ -322,6 +325,7 @@ void MIDIDeviceBase::write_packed(uint32_t data)
 				tx2_count = tx_max;
 				queue_Data_Transfer(txpipe, tx_buffer2, tx_max*4, this);
 			}
+                        __enable_irq();
 			return;
 		}
 	}


### PR DESCRIPTION
Fixed race condition in midi transmit that could happen with heavy write traffic, in combination with reading. This would lock up the usb host device, when it happened. Disabling interrupts around access to the data queue in write_packed() matches what read() is already doing, so this seems like the correct solution.