### PR TITLE
USBSerial_BigBuffer - T4.x (multi devices)

### DIFF
--- a/examples/Test/SerialTest/SerialTest.ino
+++ b/examples/Test/SerialTest/SerialTest.ino
@@ -12,7 +12,17 @@ USBHub hub2(myusb);
 USBHIDParser hid1(myusb);
 USBHIDParser hid2(myusb);
 USBHIDParser hid3(myusb);
-USBSerial userial(myusb);
+
+// There is now two versions of the USBSerial class, that are both derived from a common Base class
+// The difference is on how large of transfers that it can handle.  This is controlled by
+// the device descriptor, where up to now we handled those up to 64 byte USB transfers.
+// But there are now new devices that support larger transfer like 512 bytes.  This for example
+// includes the Teensy 4.x boards.  For these we need the big buffer version. 
+// uncomment one of the following defines for userial
+USBSerial userial(myusb);  // works only for those Serial devices who transfer <=64 bytes (like T3.x, FTDI...)
+//USBSerial_BigBuffer userial(myusb, 1); // Handles anything up to 512 bytes
+//USBSerial_BigBuffer userial(myusb); // Handles up to 512 but by default only for those > 64 bytes
+
 
 USBDriver *drivers[] = {&hub1, &hub2, &hid1, &hid2, &hid3, &userial};
 #define CNT_DEVICES (sizeof(drivers)/sizeof(drivers[0]))

--- a/keywords.txt
+++ b/keywords.txt
@@ -8,6 +8,8 @@ DigitizerController	KEYWORD1
 MIDIDevice	KEYWORD1
 MIDIDevice_BigBuffer	KEYWORD1
 USBSerial	KEYWORD1
+USBSerial_BigBuffer	KEYWORD1
+USBSerialBase	KEYWORD1
 AntPlus	KEYWORD1
 JoystickController	KEYWORD1
 RawHIDController	KEYWORD1


### PR DESCRIPTION
This delta originated to do the work similar to what was done
for the MIDI code base and support two versions of the object.

All of the code was renamed to a new base class USBSerialBase
which has everything, except the main buffer.

Two sub-classes were made that the only difference is the size of the
buffer to hold all of the USB RX and TX information.

This started off to try to support an FT2232H device which transers
512 bytes at a time instead of what most of our devices were transfering
which is 64 bytes.

While doing this, I found that we have a similar issue with the T4.x
boards which now transfer 512 bytes as well and our Serial object would
not handle it.

So there are two sublasses:
```
USBSerial - for those up to 64 byte transfers
USBSerial_BigBuffer - for up to 512 bytes
```

Note: by default the biguffer version will only handle those
devices > 64 bytes, but you can pass in an optional parameter of the
minimum size, so doing something like:
```
USBSerial_BigBuffer userial(myusb, 1);
```
Will handle all up to 512.

Also the FTDI2232H supports two USB to Serial objects, and our code
was setup that in most cases including when we put in VID:PID pair in
our table, the code would claim would claim
the object at device level so only one USB Serial adapter.

So changed table to support saying for this VID:PID claim at
interface level.  It now works, but not sure for the device I have as
it is a USB to Serial and JTAG and not sure how to test 2nd one.

But while doing this created a test sketch for Multiple Host USB Serial
objects and the two are claimed by this.

I also created a new version of the Teensy USBToSerial example sketch
that if you configure USB type to Dual Serial or Triple Serial will output
SerialUSB1 to Serial2 and SerialUSB2 to Serial3, which works, and then
tried T4 configured for Dual plugged
into T4.1 with above sketch and could talk to both USB Serial adapters.

The Claim code was rearranged a lot, so hopefully did not break
anything.

But tested with
T4 as mentioned, both Single and Dual Serial
T3.2  with Single Serial, plus: Serial, Joystick, Keyboard...
FTDI - USB to Serial adapter (Sparkfun)
CP2104 - Adafruit
PL2303 - some clones ...

So hopefully most things are still working