### PR TITLE
Separate MIDI parsing from USB communication

### DIFF
--- a/USBHost_t36.h
+++ b/USBHost_t36.h
@@ -1032,7 +1032,60 @@ private:
 
 //--------------------------------------------------------------------------
 
-class MIDIDeviceBase : public USBDriver {
+class LowLevelMIDIDeviceBase : public USBDriver {
+public:
+
+	LowLevelMIDIDeviceBase(USBHost &host, uint32_t *rx, uint32_t *tx1, uint32_t *tx2,
+		uint16_t bufsize, uint32_t *rqueue, uint16_t qsize) :
+			rx_buffer(rx), tx_buffer1(tx1), tx_buffer2(tx2),
+			rx_queue(rqueue), max_packet_size(bufsize), rx_queue_size(qsize) {
+				init();
+		}
+
+	void write_packed(uint32_t data);
+	uint32_t read_packed();
+	void send_now(void) __attribute__((always_inline)) {}
+
+protected:
+	virtual bool claim(Device_t *device, int type, const uint8_t *descriptors, uint32_t len);
+	virtual void disconnect();
+	static void rx_callback(const Transfer_t *transfer);
+	static void tx_callback(const Transfer_t *transfer);
+	void rx_data(const Transfer_t *transfer);
+	void tx_data(const Transfer_t *transfer);
+	void init();
+private:
+	Pipe_t *rxpipe;
+	Pipe_t *txpipe;
+	//enum { MAX_PACKET_SIZE = 64 };
+	//enum { RX_QUEUE_SIZE = 80 }; // must be more than MAX_PACKET_SIZE/4
+	//uint32_t rx_buffer[MAX_PACKET_SIZE/4];
+	//uint32_t tx_buffer1[MAX_PACKET_SIZE/4];
+	//uint32_t tx_buffer2[MAX_PACKET_SIZE/4];
+	uint32_t * const rx_buffer;
+	uint32_t * const tx_buffer1;
+	uint32_t * const tx_buffer2;
+	uint16_t rx_size;
+	uint16_t tx_size;
+	//uint32_t rx_queue[RX_QUEUE_SIZE];
+	uint32_t * const rx_queue;
+	bool rx_packet_queued;
+	const uint16_t max_packet_size;
+	const uint16_t rx_queue_size;
+	uint16_t rx_head;
+	uint16_t rx_tail;
+	volatile uint8_t tx1_count;
+	volatile uint8_t tx2_count;
+	uint8_t rx_ep;
+	uint8_t tx_ep;
+	uint8_t rx_ep_type;
+	uint8_t tx_ep_type;
+	Pipe_t mypipes[3] __attribute__ ((aligned(32)));
+	Transfer_t mytransfers[7] __attribute__ ((aligned(32)));
+	strbuf_t mystring_bufs[1];
+};
+
+class MIDIDeviceBase : protected LowLevelMIDIDeviceBase {
 public:
 	enum { SYSEX_MAX_LEN = 290 };
 
@@ -1058,12 +1111,7 @@ public:
 		ActiveSensing         = 0xFE, // System Real Time - Active Sensing
 		SystemReset           = 0xFF, // System Real Time - System Reset
 	};
-	MIDIDeviceBase(USBHost &host, uint32_t *rx, uint32_t *tx1, uint32_t *tx2,
-		uint16_t bufsize, uint32_t *rqueue, uint16_t qsize) :
-			rx_buffer(rx), tx_buffer1(tx1), tx_buffer2(tx2),
-			rx_queue(rqueue), max_packet_size(bufsize), rx_queue_size(qsize) {
-				init();
-		}
+	using LowLevelMIDIDeviceBase::LowLevelMIDIDeviceBase;
 	void sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel, uint8_t cable=0) {
 		send(0x80, note, velocity, channel, cable);
 	}
@@ -1182,8 +1230,7 @@ public:
 			  | ((data1 & 0x7F) << 16) | ((data2 & 0x7F) << 24));
 		}
 	}
-	void send_now(void) __attribute__((always_inline)) {
-	}
+	using LowLevelMIDIDeviceBase::send_now;
 	bool read(uint8_t channel=0);
 	uint8_t getType(void) {
 		return msg_type;
@@ -1299,73 +1346,37 @@ public:
 		handleRealTimeSystem = fptr;
 	}
 protected:
-	virtual bool claim(Device_t *device, int type, const uint8_t *descriptors, uint32_t len);
-	virtual void disconnect();
-	static void rx_callback(const Transfer_t *transfer);
-	static void tx_callback(const Transfer_t *transfer);
-	void rx_data(const Transfer_t *transfer);
-	void tx_data(const Transfer_t *transfer);
-	void init();
-	void write_packed(uint32_t data);
 	void send_sysex_buffer_has_term(const uint8_t *data, uint32_t length, uint8_t cable);
 	void send_sysex_add_term_bytes(const uint8_t *data, uint32_t length, uint8_t cable);
 	void sysex_byte(uint8_t b);
 private:
-	Pipe_t *rxpipe;
-	Pipe_t *txpipe;
-	//enum { MAX_PACKET_SIZE = 64 };
-	//enum { RX_QUEUE_SIZE = 80 }; // must be more than MAX_PACKET_SIZE/4
-	//uint32_t rx_buffer[MAX_PACKET_SIZE/4];
-	//uint32_t tx_buffer1[MAX_PACKET_SIZE/4];
-	//uint32_t tx_buffer2[MAX_PACKET_SIZE/4];
-	uint32_t * const rx_buffer;
-	uint32_t * const tx_buffer1;
-	uint32_t * const tx_buffer2;
-	uint16_t rx_size;
-	uint16_t tx_size;
-	//uint32_t rx_queue[RX_QUEUE_SIZE];
-	uint32_t * const rx_queue;
-	bool rx_packet_queued;
-	const uint16_t max_packet_size;
-	const uint16_t rx_queue_size;
-	uint16_t rx_head;
-	uint16_t rx_tail;
-	volatile uint8_t tx1_count;
-	volatile uint8_t tx2_count;
-	uint8_t rx_ep;
-	uint8_t tx_ep;
-	uint8_t rx_ep_type;
-	uint8_t tx_ep_type;
-	uint8_t msg_cable;
-	uint8_t msg_channel;
-	uint8_t msg_type;
-	uint8_t msg_data1;
-	uint8_t msg_data2;
+	uint8_t msg_cable = 0;
+	uint8_t msg_channel = 0;
+	uint8_t msg_type = 0;
+	uint8_t msg_data1 = 0;
+	uint8_t msg_data2 = 0;
 	uint8_t msg_sysex[SYSEX_MAX_LEN];
-	uint16_t msg_sysex_len;
-	void (*handleNoteOff)(uint8_t ch, uint8_t note, uint8_t vel);
-	void (*handleNoteOn)(uint8_t ch, uint8_t note, uint8_t vel);
-	void (*handleVelocityChange)(uint8_t ch, uint8_t note, uint8_t vel);
-	void (*handleControlChange)(uint8_t ch, uint8_t control, uint8_t value);
-	void (*handleProgramChange)(uint8_t ch, uint8_t program);
-	void (*handleAfterTouch)(uint8_t ch, uint8_t pressure);
-	void (*handlePitchChange)(uint8_t ch, int pitch);
-	void (*handleSysExPartial)(const uint8_t *data, uint16_t length, uint8_t complete);
-	void (*handleSysExComplete)(uint8_t *data, unsigned int size);
-	void (*handleTimeCodeQuarterFrame)(uint8_t data);
-	void (*handleSongPosition)(uint16_t beats);
-	void (*handleSongSelect)(uint8_t songnumber);
-	void (*handleTuneRequest)(void);
-	void (*handleClock)(void);
-	void (*handleStart)(void);
-	void (*handleContinue)(void);
-	void (*handleStop)(void);
-	void (*handleActiveSensing)(void);
-	void (*handleSystemReset)(void);
-	void (*handleRealTimeSystem)(uint8_t rtb);
-	Pipe_t mypipes[3] __attribute__ ((aligned(32)));
-	Transfer_t mytransfers[7] __attribute__ ((aligned(32)));
-	strbuf_t mystring_bufs[1];
+	uint16_t msg_sysex_len = 0;
+	void (*handleNoteOff)(uint8_t ch, uint8_t note, uint8_t vel) = nullptr;
+	void (*handleNoteOn)(uint8_t ch, uint8_t note, uint8_t vel) = nullptr;
+	void (*handleVelocityChange)(uint8_t ch, uint8_t note, uint8_t vel) = nullptr;
+	void (*handleControlChange)(uint8_t ch, uint8_t control, uint8_t value) = nullptr;
+	void (*handleProgramChange)(uint8_t ch, uint8_t program) = nullptr;
+	void (*handleAfterTouch)(uint8_t ch, uint8_t pressure) = nullptr;
+	void (*handlePitchChange)(uint8_t ch, int pitch) = nullptr;
+	void (*handleSysExPartial)(const uint8_t *data, uint16_t length, uint8_t complete) = nullptr;
+	void (*handleSysExComplete)(uint8_t *data, unsigned int size) = nullptr;
+	void (*handleTimeCodeQuarterFrame)(uint8_t data) = nullptr;
+	void (*handleSongPosition)(uint16_t beats) = nullptr;
+	void (*handleSongSelect)(uint8_t songnumber) = nullptr;
+	void (*handleTuneRequest)(void) = nullptr;
+	void (*handleClock)(void) = nullptr;
+	void (*handleStart)(void) = nullptr;
+	void (*handleContinue)(void) = nullptr;
+	void (*handleStop)(void) = nullptr;
+	void (*handleActiveSensing)(void) = nullptr;
+	void (*handleSystemReset)(void) = nullptr;
+	void (*handleRealTimeSystem)(uint8_t rtb) = nullptr;
 };
 
 class MIDIDevice : public MIDIDeviceBase {

--- a/midi.cpp
+++ b/midi.cpp
@@ -27,31 +27,11 @@
 #define print   USBHost::print_
 #define println USBHost::println_
 
-void MIDIDeviceBase::init()
+void LowLevelMIDIDeviceBase::init()
 {
 	contribute_Pipes(mypipes, sizeof(mypipes)/sizeof(Pipe_t));
 	contribute_Transfers(mytransfers, sizeof(mytransfers)/sizeof(Transfer_t));
 	contribute_String_Buffers(mystring_bufs, sizeof(mystring_bufs)/sizeof(strbuf_t));
-	handleNoteOff = NULL;
-	handleNoteOn = NULL;
-	handleVelocityChange = NULL;
-	handleControlChange = NULL;
-	handleProgramChange = NULL;
-	handleAfterTouch = NULL;
-	handlePitchChange = NULL;
-	handleSysExPartial = NULL;
-	handleSysExComplete = NULL;
-	handleTimeCodeQuarterFrame = NULL;
-	handleSongPosition = NULL;
-	handleSongSelect = NULL;
-	handleTuneRequest = NULL;
-	handleClock = NULL;
-	handleStart = NULL;
-	handleContinue = NULL;
-	handleStop = NULL;
-	handleActiveSensing = NULL;
-	handleSystemReset = NULL;
-	handleRealTimeSystem = NULL;
 	rx_head = 0;
 	rx_tail = 0;
 	rxpipe = NULL;
@@ -83,7 +63,7 @@ void MIDIDeviceBase::init()
 //   EP_CONTROL_UNDEFINED 0x00
 //   ASSOCIATION_CONTROL  0x01
 
-bool MIDIDeviceBase::claim(Device_t *dev, int type, const uint8_t *descriptors, uint32_t len)
+bool LowLevelMIDIDeviceBase::claim(Device_t *dev, int type, const uint8_t *descriptors, uint32_t len)
 {
 	// only claim at interface level
 	if (type != 1) return false;
@@ -210,30 +190,25 @@ bool MIDIDeviceBase::claim(Device_t *dev, int type, const uint8_t *descriptors, 
 	}
 	rx_head = 0;
 	rx_tail = 0;
-	msg_channel = 0;
-	msg_type = 0;
-	msg_data1 = 0;
-	msg_data2 = 0;
-	msg_sysex_len = 0;
 	// claim if either pipe created
 	return (rxpipe || txpipe);
 }
 
-void MIDIDeviceBase::rx_callback(const Transfer_t *transfer)
+void LowLevelMIDIDeviceBase::rx_callback(const Transfer_t *transfer)
 {
 	if (transfer->driver) {
-		((MIDIDevice *)(transfer->driver))->rx_data(transfer);
+		((LowLevelMIDIDeviceBase *)(transfer->driver))->rx_data(transfer);
 	}
 }
 
-void MIDIDeviceBase::tx_callback(const Transfer_t *transfer)
+void LowLevelMIDIDeviceBase::tx_callback(const Transfer_t *transfer)
 {
 	if (transfer->driver) {
-		((MIDIDevice *)(transfer->driver))->tx_data(transfer);
+		((LowLevelMIDIDeviceBase *)(transfer->driver))->tx_data(transfer);
 	}
 }
 
-void MIDIDeviceBase::rx_data(const Transfer_t *transfer)
+void LowLevelMIDIDeviceBase::rx_data(const Transfer_t *transfer)
 {
 	println("MIDIDevice Receive");
 	print("  MIDI Data: ");
@@ -266,7 +241,7 @@ void MIDIDeviceBase::rx_data(const Transfer_t *transfer)
 	}
 }
 
-void MIDIDeviceBase::tx_data(const Transfer_t *transfer)
+void LowLevelMIDIDeviceBase::tx_data(const Transfer_t *transfer)
 {
 	println("MIDIDevice transmit complete");
 	print("  MIDI Data: ");
@@ -279,7 +254,7 @@ void MIDIDeviceBase::tx_data(const Transfer_t *transfer)
 }
 
 
-void MIDIDeviceBase::disconnect()
+void LowLevelMIDIDeviceBase::disconnect()
 {
 	// should rx_queue be cleared?
 	// as-is, the user can still read MIDI messages
@@ -289,7 +264,7 @@ void MIDIDeviceBase::disconnect()
 }
 
 
-void MIDIDeviceBase::write_packed(uint32_t data)
+void LowLevelMIDIDeviceBase::write_packed(uint32_t data)
 {
 	if (!txpipe) return;
 	uint32_t tx_max = tx_size / 4;
@@ -300,7 +275,7 @@ void MIDIDeviceBase::write_packed(uint32_t data)
 			// use tx_buffer1
 			tx_buffer1[tx1++] = data;
 			tx1_count = tx1;
-                        __disable_irq();
+			__disable_irq();
 			if (tx1 >= tx_max) {
 				queue_Data_Transfer(txpipe, tx_buffer1, tx_max*4, this);
 			} else {
@@ -309,14 +284,14 @@ void MIDIDeviceBase::write_packed(uint32_t data)
 				tx1_count = tx_max;
 				queue_Data_Transfer(txpipe, tx_buffer1, tx_max*4, this);
 			}
-                        __enable_irq();
+			__enable_irq();
 			return;
 		}
 		if (tx2 < tx_max) {
 			// use tx_buffer2
 			tx_buffer2[tx2++] = data;
 			tx2_count = tx2;
-                        __disable_irq();
+			__disable_irq();
 			if (tx2 >= tx_max) {
 				queue_Data_Transfer(txpipe, tx_buffer2, tx_max*4, this);
 			} else {
@@ -325,10 +300,30 @@ void MIDIDeviceBase::write_packed(uint32_t data)
 				tx2_count = tx_max;
 				queue_Data_Transfer(txpipe, tx_buffer2, tx_max*4, this);
 			}
-                        __enable_irq();
+			__enable_irq();
 			return;
 		}
 	}
+}
+
+uint32_t LowLevelMIDIDeviceBase::read_packed() {
+	uint32_t n, head, tail, avail;
+	head = rx_head;
+	tail = rx_tail;
+	if (head == tail) return 0;
+	if (++tail >= rx_queue_size) tail = 0;
+	n = rx_queue[tail];
+	rx_tail = tail;
+	if (!rx_packet_queued && rxpipe) {
+		avail = (head < tail) ? tail - head - 1 : rx_queue_size - 1 - head + tail;
+		if (avail >= (uint32_t)(rx_size>>2)) {
+			__disable_irq();
+			queue_Data_Transfer(rxpipe, rx_buffer, rx_size, this);
+			__enable_irq();
+		}
+	}
+	println("read: ", n, HEX);
+	return n;
 }
 
 void MIDIDeviceBase::send_sysex_buffer_has_term(const uint8_t *data, uint32_t length, uint8_t cable)
@@ -377,28 +372,12 @@ void MIDIDeviceBase::send_sysex_add_term_bytes(const uint8_t *data, uint32_t len
 	}
 }
 
-
-
-
 bool MIDIDeviceBase::read(uint8_t channel)
 {
-	uint32_t n, head, tail, avail, ch, type1, type2, b1;
+	uint32_t n, ch, type1, type2, b1;
 
-	head = rx_head;
-	tail = rx_tail;
-	if (head == tail) return false;
-	if (++tail >= rx_queue_size) tail = 0;
-	n = rx_queue[tail];
-	rx_tail = tail;
-	if (!rx_packet_queued && rxpipe) {
-	        avail = (head < tail) ? tail - head - 1 : rx_queue_size - 1 - head + tail;
-		if (avail >= (uint32_t)(rx_size>>2)) {
-			__disable_irq();
-			queue_Data_Transfer(rxpipe, rx_buffer, rx_size, this);
-			__enable_irq();
-		}
-	}
-	println("read: ", n, HEX);
+	n = read_packed();
+	if (n == 0) return false;
 
 	type1 = n & 15;
 	type2 = (n >> 12) & 15;


### PR DESCRIPTION
These changes allow for easier integration with other MIDI libraries, by exposing low-level functions for reading and writing 32-bit USB-MIDI event packets directly, without having to use the callback functions for each MIDI event separately.

No new code was added, the functionality of the original `MIDIDeviceBase` class has been separated into two classes:

1. The new `LowLevelMIDIDeviceBase` class only deals with low-level MIDI over USB communication, like reading and writing 32-bit USB-MIDI event packets.
2. The `MIDIDeviceBase` class now inherits from the LowLevelMIDIDeviceBase class and parses the MIDI data, calling user-provided callbacks.

The code for reading a USB-MIDI event packet from the rx buffer and starting the next rx data transfer that was originally part of the `MIDIDeviceBase::read()` method has been moved into a separate `LowLevelMIDIDeviceBase::read_packed()` method.

I've tested the changes using `InputFunctions.ino` example, with some extra code to send MIDI notes in the main loop. A Teensy 3.2 running an usbMIDI sketch sending and receiving MIDI was connected to the USB host ports of both a T3.6 and a T4.1 to verify that MIDI USB communication using the `MIDIDevice` class still works as expected.

***

The specific reason for this pull request is to allow integration with the [tttapa/Control-Surface](https://github.com/tttapa/Control-Surface) library. The code that couples Control Surface with USBHost_t36 can be found here: [tttapa/Control-Surface#teensy-usb-host:src/MIDI_Interfaces/USBHostMIDI_Interface.hpp](https://github.com/tttapa/Control-Surface/blob/teensy-usb-host/src/MIDI_Interfaces/USBHostMIDI_Interface.hpp)