### PR TITLE
Updates for MassStorageDrivver.cpp and USBHost_t36.h

### DIFF
--- a/USBHost_t36.h
+++ b/USBHost_t36.h
@@ -62,15 +62,6 @@
 //#define USBHOST_PRINT_DEBUG
 
 
-// When developing a new driver, please edit ehci.cpp to set
-// USBHS_USBCMD_ITC to zero.  Today we set USBHS_USBCMD_ITC(1)
-// because some drivers have race conditions exposed by
-// non-delayed interrupts.  Eventually USBHS_USBCMD_ITC will
-// be changed to 0.  Please test any new driver code with
-// USBHS_USBCMD_ITC(0) so it won't break in the future when
-// this change is made!
-
-
 // This can let you control where to send the debugging messages
 //#define USBHDBGSerial	Serial1
 #ifndef USBHDBGSerial
@@ -2058,8 +2049,8 @@ public:
 
 	bool mscTransferComplete = false;
 	uint8_t mscInit(void);
-	void msReset();
-	uint8_t msGetMaxLun();
+	void msReset(uint32_t interfaceNumber);
+	uint8_t msGetMaxLun(uint32_t interfaceNumber);
 	void msCurrentLun(uint8_t lun) {currentLUN = lun;}
 	uint8_t msCurrentLun() {return currentLUN;}
 	bool available() { delay(0); return deviceAvailable; }


### PR DESCRIPTION
Paul,
I have updated the msProcessError() method so that external processing sense codes can be parsed and displayed as descriptive error strings using a sense key, additional sense codes and additional sense code qualifiers. I also modified msReset() and msGetMaxLun() methods to use an interface number with wIndex in mk_setup(). In an email I received hathach mentioned that wIndex should be set to an interface number. So far with the bNumInterfaces at 1 and bInterfaceNumber at 0. I'm not sure if this only applies to  just the control pipe. Link is here:
[https://github.com/PaulStoffregen/USBHost_t36/pull/42#discussion_r583694595](url).
