### PR TITLE
Improve MSC Reset() and GetMaxLun()

### DIFF
--- a/MassStorageDriver.cpp
+++ b/MassStorageDriver.cpp
@@ -63,6 +63,8 @@ bool msController::claim(Device_t *dev, int type, const uint8_t *descriptors, ui
 	if (descriptors[6] != 6) return false; // bInterfaceSubClass, 6 = SCSI transparent command set (SCSI Standards)
 	if (descriptors[7] != 80) return false; // bInterfaceProtocol, 80 = BULK-ONLY TRANSPORT
 
+	bInterfaceNumber = descriptors[2];
+
 	uint8_t desc_index = 9;
 	uint8_t in_index = 0xff, out_index = 0xff;
 
@@ -196,9 +198,9 @@ uint8_t msController::mscInit(void) {
 		yield();
 	} while(!available()); 
 	
-	msReset(0); // Assume bNumInterfaces = 1 for now.
+	msReset();
 	delay(500);
-	maxLUN = msGetMaxLun(0); // Assume bNumInterfaces = 1 for now
+	maxLUN = msGetMaxLun();
 
 //	msResult = msReportLUNs(&maxLUN);
 //Serial.printf("maxLUN = %d\n",maxLUN);
@@ -229,11 +231,11 @@ uint8_t msController::mscInit(void) {
 
 //---------------------------------------------------------------------------
 // Perform Mass Storage Reset
-void msController::msReset(uint32_t interfaceNumber) {
+void msController::msReset(void) {
 #ifdef DBGprint
 	Serial.printf("msReset()\n");
 #endif
-	mk_setup(setup, 0x21, 0xff, 0, interfaceNumber, 0);
+	mk_setup(setup, 0x21, 0xff, 0, bInterfaceNumber, 0);
 	queue_Control_Transfer(device, &setup, NULL, this);
 	while (!msControlCompleted) yield();
 	msControlCompleted = false;
@@ -241,12 +243,12 @@ void msController::msReset(uint32_t interfaceNumber) {
 
 //---------------------------------------------------------------------------
 // Get MAX LUN
-uint8_t msController::msGetMaxLun(uint32_t interfaceNumber) {
+uint8_t msController::msGetMaxLun(void) {
 #ifdef DBGprint
 	Serial.printf("msGetMaxLun()\n");
 #endif
 	report[0] = 0;
-	mk_setup(setup, 0xa1, 0xfe, 0, interfaceNumber, 1);
+	mk_setup(setup, 0xa1, 0xfe, 0, bInterfaceNumber, 1);
 	queue_Control_Transfer(device, &setup, report, this);
 	while (!msControlCompleted) yield();
 	msControlCompleted = false;

--- a/USBHost_t36.h
+++ b/USBHost_t36.h
@@ -2049,8 +2049,8 @@ public:
 
 	bool mscTransferComplete = false;
 	uint8_t mscInit(void);
-	void msReset(uint32_t interfaceNumber);
-	uint8_t msGetMaxLun(uint32_t interfaceNumber);
+	void msReset(void);
+	uint8_t msGetMaxLun(void);
 	void msCurrentLun(uint8_t lun) {currentLUN = lun;}
 	uint8_t msCurrentLun() {return currentLUN;}
 	bool available() { delay(0); return deviceAvailable; }
@@ -2093,6 +2093,7 @@ private:
 	uint32_t packetSizeOut;
 	Pipe_t *datapipeIn;
 	Pipe_t *datapipeOut;
+	uint8_t bInterfaceNumber;
 	uint32_t endpointIn = 0;
 	uint32_t endpointOut = 0;
 	setup_t setup;


### PR DESCRIPTION
This add bInterfaceNumber member to use with msReset() and msGetMaxLun() as follow up to #55 . The bInterfaceNumber is part of interface descriptors and can be saved while `claim()` interface to be used with reset and get maxlun later on. It is not actually the case where interface is passed by application, sorry for not being clear enough on the comment at https://github.com/PaulStoffregen/USBHost_t36/pull/42#discussion_r583694595 

This PR is tested with single MSC class as well as composite device that has CDC as first interface (0,1) and msc as 2nd interface (2)