### PR TITLE
Experiment - Add a msReadSectorsWithCB function

### DIFF
--- a/MassStorageDriver.cpp
+++ b/MassStorageDriver.cpp
@@ -318,20 +318,20 @@ uint8_t msController::msDoCommand(msCommandBlockWrapper_t *CBW,	void *buffer)
 	println("msDoCommand()");
 #endif	
 	if(CBWTag == 0xFFFFFFFF) CBWTag = 1;
-	digitalWriteFast(2, HIGH);
+	// digitalWriteFast(2, HIGH);
 	queue_Data_Transfer(datapipeOut, CBW, sizeof(msCommandBlockWrapper_t), this); // Command stage.
 	while(!msOutCompleted) yield();
-	digitalWriteFast(2, LOW);
+	// digitalWriteFast(2, LOW);
 	msOutCompleted = false;
 	if((CBW->Flags == CMD_DIR_DATA_IN)) { // Data stage from device.
 		queue_Data_Transfer(datapipeIn, buffer, CBW->TransferLength, this);
 	while(!msInCompleted) yield();
-	digitalWriteFast(2, HIGH);
+	// digitalWriteFast(2, HIGH);
 	msInCompleted = false;
 	} else {							  // Data stage to device.
 		queue_Data_Transfer(datapipeOut, buffer, CBW->TransferLength, this);
 	while(!msOutCompleted) yield();
-	digitalWriteFast(2, LOW);
+	// digitalWriteFast(2, LOW);
 	msOutCompleted = false;
 	}
 	CSWResult = msGetCSW(); // Status stage.
@@ -578,11 +578,11 @@ uint8_t msController::msReadSectorsWithCB(
 	mscTransferComplete = false;
 
 	if(CBWTag == 0xFFFFFFFF) CBWTag = 1;
-	digitalWriteFast(2, HIGH);
+	// digitalWriteFast(2, HIGH);
 	queue_Data_Transfer(datapipeOut, &CommandBlockWrapper, sizeof(msCommandBlockWrapper_t), this); // Command stage.
 
 	while(!msOutCompleted && (_emlastRead < READ_CALLBACK_TIMEOUT_MS)) yield();
-	digitalWriteFast(2, LOW);
+	// digitalWriteFast(2, LOW);
 
 	msOutCompleted = false;
 
@@ -590,7 +590,7 @@ uint8_t msController::msReadSectorsWithCB(
 	if (_read_sectors_remaining > 1) 	queue_Data_Transfer(datapipeIn, _read_sector_buffer2, BlockSize, this);
 
 	while(!msInCompleted && (_emlastRead < READ_CALLBACK_TIMEOUT_MS)) ;
-	digitalWriteFast(2, HIGH);
+	// digitalWriteFast(2, HIGH);
 
 	if (!msInCompleted) {
 		// clear this out..

--- a/USBHost_t36.h
+++ b/USBHost_t36.h
@@ -2072,6 +2072,7 @@ public:
 
 	uint8_t msReadBlocks(const uint32_t BlockAddress, const uint16_t Blocks,
 						 const uint16_t BlockSize, void * sectorBuffer);
+	uint8_t msReadSectorsWithCB(const uint32_t BlockAddress, const uint16_t Blocks, void (*callback)(uint32_t token, uint8_t* data), uint32_t token);
 	uint8_t msWriteBlocks(const uint32_t BlockAddress, const uint16_t Blocks,
                         const uint16_t BlockSize,	const void * sectorBuffer);
 protected:
@@ -2113,6 +2114,14 @@ private:
 	volatile bool msControlCompleted = false;
 	uint32_t CBWTag = 0;
 	bool deviceAvailable = false;
+	// experiment with transfers with callbacks.
+	void (*_read_sectors_callback)(uint32_t token, uint8_t* data) = nullptr;
+	uint32_t _read_sectors_token = 0;
+	uint16_t _read_sectors_remaining = 0;
+	enum {READ_CALLBACK_TIMEOUT_MS=250};
+    elapsedMillis _emlastRead;
+	uint8_t _read_sector_buffer1[512];
+	uint8_t _read_sector_buffer2[512];
 };
 
 #endif


### PR DESCRIPTION
Experiment with the VolumeName and other MSC example scketchs in the
UsbMSCFat project, in order to get the free space faster!

This included adding timeouts as sometimes the host does not fully respond.
Try to keep the code from hanging if for some reason we don't get enough messages back from host...