### PR TITLE
Turn Bluetooth Debug off by default

### DIFF
--- a/bluetooth.cpp
+++ b/bluetooth.cpp
@@ -30,7 +30,7 @@
 #define print   USBHost::print_
 #define println USBHost::println_//#define DEBUG_BT
 
-#define DEBUG_BT
+//#define DEBUG_BT
 //#define DEBUG_BT_VERBOSE
 
 #ifndef DEBUG_BT


### PR DESCRIPTION
@PaulStoffregen and @mjs513
Forgot to disable the DEBUG_BT define so receive debug output...

Turned it off and verified it compiled for both T3.6 and T4.1