### PR TITLE
USBSerial support for setting DTR/CTS

### DIFF
--- a/USBHost_t36.h
+++ b/USBHost_t36.h
@@ -1431,6 +1431,8 @@ class USBSerialBase: public USBDriver, public Stream {
 	virtual size_t write(uint8_t c);
 	virtual void flush(void);
 
+	bool setDTR(bool fSet);
+	bool setRTS(bool fSet);
 	using Print::write;
 protected:
 	virtual bool claim(Device_t *device, int type, const uint8_t *descriptors, uint32_t len);
@@ -1484,8 +1486,10 @@ private:
 	uint8_t pl2303_v1;		// Which version do we have
 	uint8_t pl2303_v2;
 	uint8_t interface;
-	bool 	control_queued;	// Is there already a queued control messaged
+	uint8_t dtr_rts_;		// save logical state for the two of them. 
+	volatile bool 	control_queued;	// Is there already a queued control messaged
 	typedef enum { UNKNOWN=0, CDCACM, FTDI, PL2303, CH341, CP210X } sertype_t;
+
 	sertype_t sertype;
 
 	typedef struct {


### PR DESCRIPTION
As per the forum Thread: https://forum.pjrc.com/threads/67677-Kurt-USB_HOST-(T4-1)-Serial-hardware-handshake

Frank wanted the ability to write a pass through sketch that would allow him to program either an
Arduino UNO or an ESP32 that was plugged into the USBHost.

Adding support for this helped to uncover a few other issues with the code, like turned out there
was/is an long standing bug with the read code that it was reading the wrong byte from the queue.
He has another PR that addressed this.

This PR has both that fix as well as fixing Peek.

To support the reprogramming, needed to add support for allowing the host code to control both the DTR and
the RTS signals. Likewise it is needed to allow the code to change the baud rates.  This part uncovered an issue with the CP2102 code that would hang when end was called.  The end was called before we would then call begin again with a different baud rate.

So far with my version of the T4.1 sketch code, I am able to fully reprogram an arduino UNO. At least the newer ones.  Likewise was able to reprogram a Mega 1280

Likewise I can now reporgram an ESP32 as well as an ESP8266.  However so far the board after reprogramming does not successfully reboot.  You need to turn it off an on and then it runs the new program.

So far no luck with Arduino Leonardo or Due. Will try more later.