### PR TITLE
Some Fast devices like 1000hz mouse don't run full speed

### DIFF
--- a/USBHost_t36.h
+++ b/USBHost_t36.h
@@ -711,10 +711,11 @@ private:
 	setup_t setup;
 	uint8_t descriptor[800];
 	uint8_t report[64];
+	uint8_t report2[64];
 	uint16_t descsize;
 	bool use_report_id;
 	Pipe_t mypipes[3] __attribute__ ((aligned(32)));
-	Transfer_t mytransfers[4] __attribute__ ((aligned(32)));
+	Transfer_t mytransfers[5] __attribute__ ((aligned(32)));
 	strbuf_t mystring_bufs[1];
 	uint8_t txstate = 0;
 	uint8_t *tx1 = nullptr;

--- a/hid.cpp
+++ b/hid.cpp
@@ -173,6 +173,7 @@ void USBHIDParser::control(const Transfer_t *transfer)
 		println("  got report descriptor");
 		parse();
 		queue_Data_Transfer(in_pipe, report, in_size, this);
+		queue_Data_Transfer(in_pipe, report2, in_size, this);
 		if (device->idVendor == 0x054C && 
 				((device->idProduct == 0x0268) || (device->idProduct == 0x042F)/* || (device->idProduct == 0x03D5)*/)) {
 			println("send special PS3 feature command");
@@ -242,7 +243,8 @@ void USBHIDParser::in_data(const Transfer_t *transfer)
 			}
 		}
 	}
-	queue_Data_Transfer(in_pipe, report, in_size, this);
+	if (buf == report2) queue_Data_Transfer(in_pipe, report2, in_size, this);
+	else queue_Data_Transfer(in_pipe, report, in_size, this);
 }
 
 


### PR DESCRIPTION
@PaulStoffregen  - 
I simply added second buffer and input transfer and
the speed for Glorious Mouse 1000hz went up from
about 500hz to about 900+...

Also appears to resolve the issue that mcrc was reporting...

Not sure if you want it quick and dirty, with extra buffer, of if instead try to split current buffer in half as the buffers are 64 bytes long and in this case I think the messages are only 8 bytes...