### PR TITLE
Increased the descriptor buffer to 2k

### DIFF
--- a/enumeration.cpp
+++ b/enumeration.cpp
@@ -44,7 +44,7 @@ static USBDriver *available_drivers = NULL;
 // Static buffers used during enumeration.  One a single USB device
 // may enumerate at once, because USB address zero is used, and
 // because this static buffer & state info can't be shared.
-static uint8_t enumbuf[512] __attribute__ ((aligned(16)));
+static uint8_t enumbuf[2048] __attribute__ ((aligned(16)));
 static setup_t enumsetup __attribute__ ((aligned(16)));
 static uint16_t enumlen;
 


### PR DESCRIPTION
This change is to support more devices.  Even my 20 year old BRC2000 has a descriptor size of almost 1k.  iConnectivety devices typically have descriptors over 1k.  By implementing this change you will avoid repetitive posts in the forums about people have issues connecting their class compliant devices to the host port.