### PR TITLE
fix unitialized memory to allow more strict build flags

### DIFF
--- a/hid.cpp
+++ b/hid.cpp
@@ -338,7 +338,7 @@ void USBHIDParser::parse()
 			p += *p + 3;
 			continue;
 		}
-		uint32_t val;
+		uint32_t val = 0;
 		switch (tag & 0x03) { // Short Item data
 		  case 0: val = 0;
 			p++;
@@ -498,7 +498,7 @@ void USBHIDParser::parse(uint16_t type_and_report_id, const uint8_t *data, uint3
 			p += p[1] + 3;
 			continue;
 		}
-		uint32_t val;
+		uint32_t val = 0;
 		switch (tag & 0x03) { // Short Item data
 		  case 0: val = 0;
 			p++;


### PR DESCRIPTION
C:\Users\niteris\.platformio\packages\framework-arduinoteensy\libraries\USBHost_t36\hid.cpp: In member function 'void USBHIDParser::parse()':
C:\Users\niteris\.platformio\packages\framework-arduinoteensy\libraries\USBHost_t36\hid.cpp:361:20: warning: 'val' may be used uninitialized in this function [-Wmaybe-uninitialized]
    usage_page = val;
                    ^
C:\Users\niteris\.platformio\packages\framework-arduinoteensy\libraries\USBHost_t36\hid.cpp: In member function 'void USBHIDParser::parse(uint16_t, const uint8_t*, uint32_t)':
C:\Users\niteris\.platformio\packages\framework-arduinoteensy\libraries\USBHost_t36\hid.cpp:524:37: warning: 'val' may be used uninitialized in this function [-Wmaybe-uninitialized]
    logical_max = signedval(val, tag);