### PR TITLE
Added new PID for Silex CP210X.

### DIFF
--- a/serial.cpp
+++ b/serial.cpp
@@ -56,7 +56,8 @@ USBSerialBase::product_vendor_mapping_t USBSerialBase::pid_vid_mapping[] = {
 	{0x1a86, 0x5523, USBSerialBase::CH341, 0 },
 
 	// Silex CP210...
-	{0x10c4, 0xea60, USBSerialBase::CP210X, 0 }
+	{0x10c4, 0xea60, USBSerialBase::CP210X, 0 },
+	{0x10c4, 0xea70, USBSerialBase::CP210X, 0 }
 };
 
 


### PR DESCRIPTION
I used this library to connect a Teensy to a Yaesu FT-891 amateur radio transceiver.  It would not see the radio until I added the new line with the PID for the CP2105 chip.