### PR TITLE
Bump version

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=USBHost_t36
-version=0.1
+version=0.2
 author=Paul Stoffregen
 maintainer=Paul Stoffregen
 sentence=Connect USB devices to the USB Host of Teensy 3.6 and Teensy 4.x


### PR DESCRIPTION
In the PlatformIO registry, the library is stuck at 0.1 because that's the only version this library was ever at (https://registry.platformio.org/libraries/paulstoffregen/USBHost_t36/versions).

Bumping up the version to trigger a recrawl for PlatformIO (and possibly Arduino IDE library managers).