### PR TITLE
Keyboard should not claim topusages meant for Mouse or Joystick

### DIFF
--- a/hid.cpp
+++ b/hid.cpp
@@ -250,7 +250,7 @@ void USBHIDParser::in_data(const Transfer_t *transfer)
 
 void USBHIDParser::out_data(const Transfer_t *transfer)
 {
-	Serial.printf(">>>USBHIDParser::out_data\n");
+	//Serial.printf(">>>USBHIDParser::out_data\n");
 	println("USBHIDParser:out_data called (instance)");
 	// A packet completed. lets mark it as done and call back
 	// to top reports handler.  We unmark our checkmark to

--- a/joystick.cpp
+++ b/joystick.cpp
@@ -396,6 +396,8 @@ bool JoystickController::transmitPS3MotionUserFeedbackMsg() {
 
 hidclaim_t JoystickController::claim_collection(USBHIDParser *driver, Device_t *dev, uint32_t topusage)
 {
+	//USBHDBGSerial.printf("JoystickController::claim_collection(%p) Driver:%p(%u %u) Dev:%p Top:%x\n", this, driver, 
+	//	driver->interfaceSubClass(), driver->interfaceProtocol(), dev, topusage);
 	// only claim Desktop/Joystick and Desktop/Gamepad
 	if (topusage != 0x10004 && topusage != 0x10005 && topusage != 0x10008) return CLAIM_NO;
 	// only claim from one physical device
@@ -434,7 +436,8 @@ hidclaim_t JoystickController::claim_collection(USBHIDParser *driver, Device_t *
 			additional_axis_usage_count_ = 5;
 			axis_change_notify_mask_ = 0x3ff;	// Start off assume only the 10 bits...
 	}
-	DBGPrintf("Claim Additional axis: %x %x %d\n", additional_axis_usage_page_, additional_axis_usage_start_, additional_axis_usage_count_);
+	//DBGPrintf("Claim Additional axis: %x %x %d\n", additional_axis_usage_page_, additional_axis_usage_start_, additional_axis_usage_count_);
+	USBHDBGSerial.printf("\tJoystickController claim collection\n");
 	return CLAIM_REPORT;
 }
 

--- a/keyboard.cpp
+++ b/keyboard.cpp
@@ -352,7 +352,11 @@ hidclaim_t KeyboardController::claim_collection(USBHIDParser *driver, Device_t *
 
 	if (mydevice != NULL && dev != mydevice) return CLAIM_NO;
 
+	// We will not claim mouse protocol
+	if (driver->interfaceProtocol() == 2) return CLAIM_NO;
+
 	// We will claim if BOOT Keyboard.
+
 	if (((driver->interfaceSubClass() == 1) && (driver->interfaceProtocol() == 1)) 
 		|| (topusage == TOPUSAGE_KEYBOARD))
 	{
@@ -365,15 +369,16 @@ hidclaim_t KeyboardController::claim_collection(USBHIDParser *driver, Device_t *
 		} 
 
      } else if ((topusage == TOPUSAGE_CONSUMER_CONTROL) 
-			 || (topusage == TOPUSAGE_SYS_CONTROL) 
-			 || ((topusage & 0xfffffff0) == 0x10000))  { // See if we can catch the secondary ones. 
+			 || (topusage == TOPUSAGE_SYS_CONTROL) ) {
+
 		driver_[1] = driver;
+
      } else {
 		return CLAIM_NO;
 	}
 	mydevice = dev;
 	collections_claimed_++;
-	//USBHDBGSerial.printf("KeyboardController claim collection\n");
+	//USBHDBGSerial.printf("\tKeyboardController claim collection\n");
 	return CLAIM_REPORT;
 }
 
@@ -404,7 +409,7 @@ bool KeyboardController::hid_process_in_data(const Transfer_t *transfer)
 		keyboard_uses_boot_format_  = true;
 		return true;
 	}
-	USBHDBGSerial.printf("\n");
+	//USBHDBGSerial.printf("\n");
 
 	return false;
 }

--- a/mouse.cpp
+++ b/mouse.cpp
@@ -35,11 +35,15 @@ void MouseController::init()
 hidclaim_t MouseController::claim_collection(USBHIDParser *driver, Device_t *dev, uint32_t topusage)
 {
 	// only claim Desktop/Mouse
+	//USBHDBGSerial.printf("MouseController::claim_collection(%p) Driver:%p(%u %u) Dev:%p Top:%x\n", this, driver, 
+	//	driver->interfaceSubClass(), driver->interfaceProtocol(), dev, topusage);
+
 	if ((topusage != 0x10002) && (topusage != 0x10001)) return CLAIM_NO;
 	// only claim from one physical device
 	if (mydevice != NULL && dev != mydevice) return CLAIM_NO;
 	mydevice = dev;
 	collections_claimed++;
+	//USBHDBGSerial.printf("\tMouseController claim collection\n");
 	return CLAIM_REPORT;
 }
 


### PR DESCRIPTION
There was an issue with supporting some of the more advanced keyboards where
we thought we needed to claim more topusages in the generic desktop HID page

So, we were claiming too many which causes issues where it was claiming ones that
should be claimed by Mouse or Joystcik.

So removed the extras claiming code.

Also comment out some debug outputs that were left in earlier and also 
updated a few of the output comments to see who was claiming what.
But these are also commented out.
