### PR TITLE
Update Storage Examples

### DIFF
--- a/MassStorageDriver.cpp
+++ b/MassStorageDriver.cpp
@@ -1471,42 +1471,6 @@ bool USBFilesystem::check_voltype_guid(int voltype, uint8_t *guid) {
 	return true;
 }
 
-//=============================================================================
-// USBFilesystem::begin - Manual way to startup a filesystem object
-//=============================================================================
-
-bool USBFilesystem::begin(USBDrive *pDrive, bool setCwv, uint8_t part) {
-	DBGPrintf(">>USBFilesystem::begin(%p, %u, %u)\n", pDrive, setCwv, part); DBGFlush();
-	if (device) return false;  // object is already in use. 
-	uint8_t guid[16];
-	device = pDrive;
-	device->begin();
-	if (device->errorCode() != 0) return false;
-	//device->printPartionTable(Serial);
-	int type;
-	uint32_t firstSector, numSectors;
-	uint32_t mbrLBA;
-	uint8_t mbrPart;
-
-
-	int voltype = device->findPartition(part, type, firstSector, numSectors, mbrLBA, mbrPart, guid);
-	if (!voltype) {
-		device = nullptr;
-		return false;  // not a valid volume...
-	}
-
-	// if this is a GPT setup, then make sure the guid is one we want.
-	if (!check_voltype_guid(voltype, guid)) {
-		device = nullptr;
-		return false;
-	}
-
-	if (mscfs.begin(pDrive, setCwv, firstSector, numSectors)) {
-		device->filesystem_assign_to_drive(this, true);
-	}
-	return true;
-}
-
 void USBFilesystem::end() {
 	mscfs.end();
 	_state_changed = USBFS_STATE_CHANGE_CONNECTION;

--- a/USBHost_t36.h
+++ b/USBHost_t36.h
@@ -2261,8 +2261,6 @@ public:
 	int findPartition(int partition, int &type, uint32_t &firstSector, uint32_t &numSectors, 
 				   uint32_t &mbrLBA, uint8_t &mbrPart, uint8_t *guid=nullptr);
 
-	static void filesystem_ready_for_drive(USBFSBase *fsbase);
-	void filesystem_assign_to_drive(USBFSBase *fsbase, bool busy);
 
 public:
 	// Functions for SdFat FsBlockDeviceInterface
@@ -2503,8 +2501,6 @@ public:
 	USBFilesystem(USBHost &host) : USBFSBase() { init(); }
 	USBFilesystem(USBHost *host) : USBFSBase() { init(); }
 
-	// Manual way to associate a drive/partition to a Filesystem object
-	bool begin(USBDrive *pDrive, bool setCwv = true, uint8_t part = 1);
 	void end();
 	void init();
 	

--- a/examples/Storage/DriveInfo/DriveInfo.ino
+++ b/examples/Storage/DriveInfo/DriveInfo.ino
@@ -3,18 +3,12 @@
 // Setup USBHost_t36 and as many HUB ports as needed.
 USBHost myusb;
 USBHub hub1(myusb);
-USBHub hub2(myusb);
-USBHub hub3(myusb);
-USBHub hub4(myusb);
 
-// Instances for the number of USB drives you are using.
-USBDrive myDrive1(myusb);
-USBDrive myDrive2(myusb);
+// Instances for one drive
+USBDrive myDrive(myusb);
 
-// Instances for accessing the files on each drive
-USBFilesystem myFiles1(myusb);
-USBFilesystem myFiles2(myusb);
-
+// Instances for accessing the files on the drive
+USBFilesystem myFiles(myusb);
 
 // Show USB drive information for the selected USB drive.
 void printDriveInfo(USBDrive &drive) {
@@ -83,29 +77,25 @@ void setup()
   }
 
   myusb.begin();
-  Serial.println("\nInitializing USB drive 1...");
-  // future USBFilesystem will begin automatically
-  // begin(USBDrive) is a temporary feature
-  if (!myFiles1.begin(&myDrive1)) {
-    Serial.print("initialization failed with code: ");
-    myFiles1.printError(Serial);
-    return;
-  }
-  Serial.printf("Device 1 Info:\n");
-  printDriveInfo(myDrive1);
-  printFilesystemInfo(myFiles1);
+  Serial.println("\nWaiting for Drive to initialize...");
 
-  Serial.println("\nInitializing USB drive 2...");
-  // future USBFilesystem will begin automatically
-  // begin(USBDrive) is a temporary feature
-  if (!myFiles2.begin(&myDrive2)) {
-    Serial.print("initialization failed with code: ");
-    myFiles2.printError(Serial);
-    return;
+  // Wait for the drive to start.
+  while (!myDrive) {
+    myusb.Task();
   }
-  Serial.printf("Device 2 Info:\n");
-  printDriveInfo(myDrive2);
-  printFilesystemInfo(myFiles2);
+
+  Serial.printf("Device Info:\n");
+  printDriveInfo(myDrive);
+
+  elapsedMillis em;
+  while (!myFiles && (em < 1000)) {
+    myusb.Task();
+  }
+  if (myFiles) {
+    printFilesystemInfo(myFiles);
+  } else {
+    Serial.println("\n*** No Fat Filesystem Partitions found on drive **");
+  }
 }
 
 

--- a/examples/Storage/ListFiles/ListFiles.ino
+++ b/examples/Storage/ListFiles/ListFiles.ino
@@ -37,13 +37,10 @@ void setup()
   // Start USBHost_t36, HUB(s) and USB devices.
   myusb.begin();
 
-  Serial.print("\nInitializing USB MSC drive...");
+  Serial.print("\nWaiting for partition to...");
 
-  // future USBFilesystem will begin automatically
-  // begin(USBDrive) is a temporary feature
-  if (!firstPartition.begin(&myDrive)) {
-    Serial.println("initialization failed!");
-    return;
+  while (!firstPartition) {
+    myusb.Task();
   }
   Serial.println("initialization done.");
 

--- a/examples/Storage/WavFilePlayerUSB/WavFilePlayerUSB.ino
+++ b/examples/Storage/WavFilePlayerUSB/WavFilePlayerUSB.ino
@@ -32,24 +32,20 @@
 #include "play_usb_wav.h" // Should be included in 'Audio.h'
 #include <Wire.h>
 #include <SPI.h>
-#include <SD.h>
-#include <SerialFlash.h>
+//#include <SD.h>
+//#include <SerialFlash.h>
 
 // Setup USBHost_t36 and as many HUB ports as needed.
 USBHost myusb;
 USBHub hub1(myusb);
-USBHub hub2(myusb);
-USBHub hub3(myusb);
-USBHub hub4(myusb);
 
 // Setup MSC for the number of USB Drives you are using. (Two for this example)
 // Mutiple  USB drives can be used. Hot plugging is supported. There is a slight
 // delay after a USB MSC device is plugged in. This is waiting for initialization
 // but after it is initialized ther should be no delay.
 USBDrive msDrive1(myusb);
-USBDrive msDrive2(myusb);
 
-USBFilesystem MSC(myusb);
+USBFilesystem myFS(myusb);
 
 AudioPlayUSBWav           playWav1;
 // Use one of these 3 output types: Digital I2S, Digital S/PDIF, or Analog DAC
@@ -61,12 +57,18 @@ AudioConnection          patchCord2(playWav1, 1, audioOutput, 1);
 AudioControlSGTL5000     sgtl5000_1;
 
 void setup() {
-  Serial.begin(9600);
   // Wait for USB Serial
   while (!Serial) {
     yield();
   }
-
+  Serial.println("WaveFilePlayerUSB Started");
+  if (CrashReport) {
+    Serial.print(CrashReport);
+    Serial.println("Press any key to continue");
+    while (Serial.read() != -1);
+    while (Serial.read() == -1);
+  }
+  
   // Start USBHost_t36, HUB(s) and USB devices.
   myusb.begin();
 
@@ -80,25 +82,21 @@ void setup() {
   sgtl5000_1.enable();
   sgtl5000_1.volume(0.50);
 
-  // future USBFilesystem will begin automatically
-  // begin(USBDrive) is a temporary feature
-  if (!MSC.begin(&msDrive1)) {
-    // stop here, but print a message repetitively
-    while (1) {
-      Serial.println("Unable to access the USB drive");
-      delay(500);
-    }
+  Serial.println("Waiting for USB Filesystem");
+  while (!myFS) {
+    myusb.Task();
   }
+  Serial.println("Filesystem started");
 }
 
-void playFile(const char *filename)
+void playFile(File *pfile, const char *filename)
 {
   Serial.print("Playing file: ");
   Serial.println(filename);
 
   // Start playing the file.  This sketch continues to
   // run while the file plays.
-  playWav1.play(filename);
+  playWav1.play(pfile);
 
   // A brief delay for the library read WAV info
   delay(5);
@@ -115,14 +113,24 @@ void playFile(const char *filename)
 
 
 void loop() {
-  playFile("ARMAGED.WAV");  // filenames are always uppercase 8.3 format
-  delay(500);
-  playFile("SDTEST1.WAV");  // filenames are always uppercase 8.3 format
-  delay(500);
-  playFile("SDTEST2.WAV");
-  delay(500);
-  playFile("SDTEST3.WAV");
-  delay(500);
-  playFile("SDTEST4.WAV");
+  File rootFile;
+  File wavFile;
+  const char *name = nullptr;
+  uint8_t name_len;
+  bool wav_files_found = false;
+  rootFile = myFS.open("/");
+  for (;;) {
+    wavFile = rootFile.openNextFile();
+    if (!wavFile) break;
+      name = wavFile.name();
+      name_len = strlen(name);
+      if ((strcmp(&name[name_len - 4], ".wav") == 0) || (strcmp(&name[name_len - 4], ".WAV") == 0)) {
+        wav_files_found = true;
+        playFile(&wavFile, name);  
+        delay(500);
+      }
+      wavFile.close();
+  }
   delay(1500);
+  rootFile.close();
 }

--- a/examples/Storage/WavFilePlayerUSB/WavFilePlayerUSB.ino
+++ b/examples/Storage/WavFilePlayerUSB/WavFilePlayerUSB.ino
@@ -25,11 +25,11 @@
 //
 // This example code is in the public domain.
 
- // Modified for use with USB mass storage drives 2020 Warren Watson
+// Modified for use with USB mass storage drives 2020 Warren Watson
 
 #include <USBHost_t36.h>
 #include <Audio.h>
-#include "play_usb_wav.h" // Should be included in 'Audio.h'
+#include "play_usb_wav.h"  // Should be included in 'Audio.h'
 #include <Wire.h>
 #include <SPI.h>
 //#include <SD.h>
@@ -47,14 +47,14 @@ USBDrive msDrive1(myusb);
 
 USBFilesystem myFS(myusb);
 
-AudioPlayUSBWav           playWav1;
+AudioPlayUSBWav playWav1;
 // Use one of these 3 output types: Digital I2S, Digital S/PDIF, or Analog DAC
-AudioOutputI2S           audioOutput;
+AudioOutputI2S audioOutput;
 //AudioOutputSPDIF       audioOutput;
 //AudioOutputAnalog      audioOutput;
-AudioConnection          patchCord1(playWav1, 0, audioOutput, 0);
-AudioConnection          patchCord2(playWav1, 1, audioOutput, 1);
-AudioControlSGTL5000     sgtl5000_1;
+AudioConnection patchCord1(playWav1, 0, audioOutput, 0);
+AudioConnection patchCord2(playWav1, 1, audioOutput, 1);
+AudioControlSGTL5000 sgtl5000_1;
 
 void setup() {
   // Wait for USB Serial
@@ -65,10 +65,12 @@ void setup() {
   if (CrashReport) {
     Serial.print(CrashReport);
     Serial.println("Press any key to continue");
-    while (Serial.read() != -1);
-    while (Serial.read() == -1);
+    while (Serial.read() != -1)
+      ;
+    while (Serial.read() == -1)
+      ;
   }
-  
+
   // Start USBHost_t36, HUB(s) and USB devices.
   myusb.begin();
 
@@ -89,8 +91,7 @@ void setup() {
   Serial.println("Filesystem started");
 }
 
-void playFile(File *pfile, const char *filename)
-{
+void playFile(File *pfile, const char *filename) {
   Serial.print("Playing file: ");
   Serial.println(filename);
 
@@ -122,14 +123,18 @@ void loop() {
   for (;;) {
     wavFile = rootFile.openNextFile();
     if (!wavFile) break;
-      name = wavFile.name();
-      name_len = strlen(name);
-      if ((strcmp(&name[name_len - 4], ".wav") == 0) || (strcmp(&name[name_len - 4], ".WAV") == 0)) {
-        wav_files_found = true;
-        playFile(&wavFile, name);  
-        delay(500);
-      }
-      wavFile.close();
+    name = wavFile.name();
+    name_len = strlen(name);
+    if ((strcmp(&name[name_len - 4], ".wav") == 0) || (strcmp(&name[name_len - 4], ".WAV") == 0)) {
+      wav_files_found = true;
+      playFile(&wavFile, name);
+      delay(500);
+    }
+    wavFile.close();
+  }
+  if (!wav_files_found) {
+    Serial.println("There were no *.wav files found in the root directory");
+    delay(5000);
   }
   delay(1500);
   rootFile.close();

--- a/examples/Storage/WavFilePlayerUSB/play_usb_wav.cpp
+++ b/examples/Storage/WavFilePlayerUSB/play_usb_wav.cpp
@@ -24,203 +24,198 @@
  * THE SOFTWARE.
  */
 
- // Modified for use with USB mass storage drives 2020 Warren Watson
+// Modified for use with USB mass storage drives 2020 Warren Watson
 
 #include <Arduino.h>
 #include <USBHost_t36.h>
 #include "play_usb_wav.h"
 #include "spi_interrupt.h"
 
-#define STATE_DIRECT_8BIT_MONO		0  // playing mono at native sample rate
-#define STATE_DIRECT_8BIT_STEREO	1  // playing stereo at native sample rate
-#define STATE_DIRECT_16BIT_MONO		2  // playing mono at native sample rate
-#define STATE_DIRECT_16BIT_STEREO	3  // playing stereo at native sample rate
-#define STATE_CONVERT_8BIT_MONO		4  // playing mono, converting sample rate
-#define STATE_CONVERT_8BIT_STEREO	5  // playing stereo, converting sample rate
-#define STATE_CONVERT_16BIT_MONO	6  // playing mono, converting sample rate
-#define STATE_CONVERT_16BIT_STEREO	7  // playing stereo, converting sample rate
-#define STATE_PARSE1			8  // looking for 20 byte ID header
-#define STATE_PARSE2			9  // looking for 16 byte format header
-#define STATE_PARSE3			10 // looking for 8 byte data header
-#define STATE_PARSE4			11 // ignoring unknown chunk after "fmt "
-#define STATE_PARSE5			12 // ignoring unknown chunk before "fmt "
-#define STATE_STOP			13
+#define STATE_DIRECT_8BIT_MONO 0      // playing mono at native sample rate
+#define STATE_DIRECT_8BIT_STEREO 1    // playing stereo at native sample rate
+#define STATE_DIRECT_16BIT_MONO 2     // playing mono at native sample rate
+#define STATE_DIRECT_16BIT_STEREO 3   // playing stereo at native sample rate
+#define STATE_CONVERT_8BIT_MONO 4     // playing mono, converting sample rate
+#define STATE_CONVERT_8BIT_STEREO 5   // playing stereo, converting sample rate
+#define STATE_CONVERT_16BIT_MONO 6    // playing mono, converting sample rate
+#define STATE_CONVERT_16BIT_STEREO 7  // playing stereo, converting sample rate
+#define STATE_PARSE1 8                // looking for 20 byte ID header
+#define STATE_PARSE2 9                // looking for 16 byte format header
+#define STATE_PARSE3 10               // looking for 8 byte data header
+#define STATE_PARSE4 11               // ignoring unknown chunk after "fmt "
+#define STATE_PARSE5 12               // ignoring unknown chunk before "fmt "
+#define STATE_STOP 13
 
-void AudioPlayUSBWav::begin(void)
-{
-	state = STATE_STOP;
-	state_play = STATE_STOP;
-	data_length = 0;
-	if (block_left) {
-		release(block_left);
-		block_left = NULL;
-	}
-	if (block_right) {
-		release(block_right);
-		block_right = NULL;
-	}
+void AudioPlayUSBWav::begin(void) {
+  state = STATE_STOP;
+  state_play = STATE_STOP;
+  data_length = 0;
+  if (block_left) {
+    release(block_left);
+    block_left = NULL;
+  }
+  if (block_right) {
+    release(block_right);
+    block_right = NULL;
+  }
 }
 
 
-bool AudioPlayUSBWav::play(File *pfile)
-{
+bool AudioPlayUSBWav::play(File *pfile) {
   wavfile = pfile;
-	stop();
-	bool irq = false;
-	if (NVIC_IS_ENABLED(IRQ_SOFTWARE)) {
-		NVIC_DISABLE_IRQ(IRQ_SOFTWARE);
-		irq = true;
-	}
+  stop();
+  bool irq = false;
+  if (NVIC_IS_ENABLED(IRQ_SOFTWARE)) {
+    NVIC_DISABLE_IRQ(IRQ_SOFTWARE);
+    irq = true;
+  }
 #if defined(HAS_KINETIS_SDHC)
-	if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStartUsingSPI();
+  if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStartUsingSPI();
 #else
-	AudioStartUsingSPI();
+  AudioStartUsingSPI();
 #endif
-	if (!*pfile) {
+  if (!*pfile) {
 #if defined(HAS_KINETIS_SDHC)
-		if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStopUsingSPI();
+    if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStopUsingSPI();
 #else
-		AudioStopUsingSPI();
+    AudioStopUsingSPI();
 #endif
-		if (irq) NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
-		return false;
-	}
-	buffer_length = 0;
-	buffer_offset = 0;
-	state_play = STATE_STOP;
-	data_length = 20;
-	header_offset = 0;
-	state = STATE_PARSE1;
-	if (irq) NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
-	return true;
+    if (irq) NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
+    return false;
+  }
+  buffer_length = 0;
+  buffer_offset = 0;
+  state_play = STATE_STOP;
+  data_length = 20;
+  header_offset = 0;
+  state = STATE_PARSE1;
+  if (irq) NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
+  return true;
 }
 
-void AudioPlayUSBWav::stop(void)
-{
-	bool irq = false;
-	if (NVIC_IS_ENABLED(IRQ_SOFTWARE)) {
-		NVIC_DISABLE_IRQ(IRQ_SOFTWARE);
-		irq = true;
-	}
-	if (state != STATE_STOP) {
-		audio_block_t *b1 = block_left;
-		block_left = NULL;
-		audio_block_t *b2 = block_right;
-		block_right = NULL;
-		state = STATE_STOP;
-		if (b1) release(b1);
-		if (b2) release(b2);
-		//wavfile->close();
+void AudioPlayUSBWav::stop(void) {
+  bool irq = false;
+  if (NVIC_IS_ENABLED(IRQ_SOFTWARE)) {
+    NVIC_DISABLE_IRQ(IRQ_SOFTWARE);
+    irq = true;
+  }
+  if (state != STATE_STOP) {
+    audio_block_t *b1 = block_left;
+    block_left = NULL;
+    audio_block_t *b2 = block_right;
+    block_right = NULL;
+    state = STATE_STOP;
+    if (b1) release(b1);
+    if (b2) release(b2);
+      //wavfile->close();
 #if defined(HAS_KINETIS_SDHC)
-		if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStopUsingSPI();
+    if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStopUsingSPI();
 #else
-		AudioStopUsingSPI();
+    AudioStopUsingSPI();
 #endif
-	}
-	if (irq) NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
+  }
+  if (irq) NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
 }
 
 
-void AudioPlayUSBWav::update(void)
-{
-	int32_t n;
+void AudioPlayUSBWav::update(void) {
+  int32_t n;
 
-	// only update if we're playing
-	if (state == STATE_STOP) return;
+  // only update if we're playing
+  if (state == STATE_STOP) return;
 
-	// allocate the audio blocks to transmit
-	block_left = allocate();
-	if (block_left == NULL) return;
-	if (state < 8 && (state & 1) == 1) {
-		// if we're playing stereo, allocate another
-		// block for the right channel output
-		block_right = allocate();
-		if (block_right == NULL) {
-			release(block_left);
-			return;
-		}
-	} else {
-		// if we're playing mono or just parsing
-		// the WAV file header, no right-side block
-		block_right = NULL;
-	}
-	block_offset = 0;
+  // allocate the audio blocks to transmit
+  block_left = allocate();
+  if (block_left == NULL) return;
+  if (state < 8 && (state & 1) == 1) {
+    // if we're playing stereo, allocate another
+    // block for the right channel output
+    block_right = allocate();
+    if (block_right == NULL) {
+      release(block_left);
+      return;
+    }
+  } else {
+    // if we're playing mono or just parsing
+    // the WAV file header, no right-side block
+    block_right = NULL;
+  }
+  block_offset = 0;
 
-	//Serial.println("update");
+  //Serial.println("update");
 
-	// is there buffered data?
-	n = buffer_length - buffer_offset;
-	if (n > 0) {
-		// we have buffered data
-		if (consume(n)) return; // it was enough to transmit audio
-	}
+  // is there buffered data?
+  n = buffer_length - buffer_offset;
+  if (n > 0) {
+    // we have buffered data
+    if (consume(n)) return;  // it was enough to transmit audio
+  }
 
-	// we only get to this point when buffer[512] is empty
-	if (state != STATE_STOP && wavfile->available()) {
-		// we can read more data from the file...
-		readagain:
-		buffer_length = wavfile->read(buffer, 2048);
-		if (buffer_length == 0) goto end;
-		buffer_offset = 0;
-		bool parsing = (state >= 8);
-		bool txok = consume(buffer_length);
-		if (txok) {
-			if (state != STATE_STOP) return;
-		} else {
-			if (state != STATE_STOP) {
-				if (parsing && state < 8) goto readagain;
-				else goto cleanup;
-			}
-		}
-	}
-end:	// end of file reached or other reason to stop
-	//wavfile->close();
+  // we only get to this point when buffer[512] is empty
+  if (state != STATE_STOP && wavfile->available()) {
+// we can read more data from the file...
+readagain:
+    buffer_length = wavfile->read(buffer, 2048);
+    if (buffer_length == 0) goto end;
+    buffer_offset = 0;
+    bool parsing = (state >= 8);
+    bool txok = consume(buffer_length);
+    if (txok) {
+      if (state != STATE_STOP) return;
+    } else {
+      if (state != STATE_STOP) {
+        if (parsing && state < 8) goto readagain;
+        else goto cleanup;
+      }
+    }
+  }
+end:  // end of file reached or other reason to stop
+      //wavfile->close();
 #if defined(HAS_KINETIS_SDHC)
-	if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStopUsingSPI();
+  if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStopUsingSPI();
 #else
-	AudioStopUsingSPI();
+  AudioStopUsingSPI();
 #endif
-	state_play = STATE_STOP;
-	state = STATE_STOP;
+  state_play = STATE_STOP;
+  state = STATE_STOP;
 cleanup:
-	if (block_left) {
-		if (block_offset > 0) {
-			for (uint32_t i=block_offset; i < AUDIO_BLOCK_SAMPLES; i++) {
-				block_left->data[i] = 0;
-			}
-			transmit(block_left, 0);
-			if (state < 8 && (state & 1) == 0) {
-				transmit(block_left, 1);
-			}
-		}
-		release(block_left);
-		block_left = NULL;
-	}
-	if (block_right) {
-		if (block_offset > 0) {
-			for (uint32_t i=block_offset; i < AUDIO_BLOCK_SAMPLES; i++) {
-				block_right->data[i] = 0;
-			}
-			transmit(block_right, 1);
-		}
-		release(block_right);
-		block_right = NULL;
-	}
+  if (block_left) {
+    if (block_offset > 0) {
+      for (uint32_t i = block_offset; i < AUDIO_BLOCK_SAMPLES; i++) {
+        block_left->data[i] = 0;
+      }
+      transmit(block_left, 0);
+      if (state < 8 && (state & 1) == 0) {
+        transmit(block_left, 1);
+      }
+    }
+    release(block_left);
+    block_left = NULL;
+  }
+  if (block_right) {
+    if (block_offset > 0) {
+      for (uint32_t i = block_offset; i < AUDIO_BLOCK_SAMPLES; i++) {
+        block_right->data[i] = 0;
+      }
+      transmit(block_right, 1);
+    }
+    release(block_right);
+    block_right = NULL;
+  }
 }
 
 
 // https://ccrma.stanford.edu/courses/422/projects/WaveFormat/
 
 // Consume already buffered data.  Returns true if audio transmitted.
-bool AudioPlayUSBWav::consume(uint32_t size)
-{
-	uint32_t len;
-	uint8_t lsb, msb;
-	const uint8_t *p;
+bool AudioPlayUSBWav::consume(uint32_t size) {
+  uint32_t len;
+  uint8_t lsb, msb;
+  const uint8_t *p;
 
-	p = buffer + buffer_offset;
+  p = buffer + buffer_offset;
 start:
-	if (size == 0) return false;
+  if (size == 0) return false;
 #if 0
 	Serial.print("AudioPlaySdWav consume, ");
 	Serial.print("size = ");
@@ -234,257 +229,257 @@ start:
 	Serial.print(", state = ");
 	Serial.println(state);
 #endif
-	switch (state) {
-	  // parse wav file header, is this really a .wav file?
-	  case STATE_PARSE1:
-		len = data_length;
-		if (size < len) len = size;
-		memcpy((uint8_t *)header + header_offset, p, len);
-		header_offset += len;
-		buffer_offset += len;
-		data_length -= len;
-		if (data_length > 0) return false;
-		// parse the header...
-		if (header[0] == 0x46464952 && header[2] == 0x45564157) {
-			//Serial.println("is wav file");
-			if (header[3] == 0x20746D66) {
-				// "fmt " header
-				if (header[4] < 16) {
-					// WAV "fmt " info must be at least 16 bytes
-					break;
-				}
-				if (header[4] > sizeof(header)) {
-					// if such .wav files exist, increasing the
-					// size of header[] should accomodate them...
-					//Serial.println("WAVEFORMATEXTENSIBLE too long");
-					break;
-				}
-				//Serial.println("header ok");
-				header_offset = 0;
-				state = STATE_PARSE2;
-			} else {
-				// first chuck is something other than "fmt "
-				//Serial.print("skipping \"");
-				//Serial.printf("\" (%08X), ", __builtin_bswap32(header[3]));
-				//Serial.print(header[4]);
-				//Serial.println(" bytes");
-				header_offset = 12;
-				state = STATE_PARSE5;
-			}
-			p += len;
-			size -= len;
-			data_length = header[4];
-			goto start;
-		}
-		//Serial.println("unknown WAV header");
-		break;
+  switch (state) {
+    // parse wav file header, is this really a .wav file?
+    case STATE_PARSE1:
+      len = data_length;
+      if (size < len) len = size;
+      memcpy((uint8_t *)header + header_offset, p, len);
+      header_offset += len;
+      buffer_offset += len;
+      data_length -= len;
+      if (data_length > 0) return false;
+      // parse the header...
+      if (header[0] == 0x46464952 && header[2] == 0x45564157) {
+        //Serial.println("is wav file");
+        if (header[3] == 0x20746D66) {
+          // "fmt " header
+          if (header[4] < 16) {
+            // WAV "fmt " info must be at least 16 bytes
+            break;
+          }
+          if (header[4] > sizeof(header)) {
+            // if such .wav files exist, increasing the
+            // size of header[] should accomodate them...
+            //Serial.println("WAVEFORMATEXTENSIBLE too long");
+            break;
+          }
+          //Serial.println("header ok");
+          header_offset = 0;
+          state = STATE_PARSE2;
+        } else {
+          // first chuck is something other than "fmt "
+          //Serial.print("skipping \"");
+          //Serial.printf("\" (%08X), ", __builtin_bswap32(header[3]));
+          //Serial.print(header[4]);
+          //Serial.println(" bytes");
+          header_offset = 12;
+          state = STATE_PARSE5;
+        }
+        p += len;
+        size -= len;
+        data_length = header[4];
+        goto start;
+      }
+      //Serial.println("unknown WAV header");
+      break;
 
-	  // check & extract key audio parameters
-	  case STATE_PARSE2:
-		len = data_length;
-		if (size < len) len = size;
-		memcpy((uint8_t *)header + header_offset, p, len);
-		header_offset += len;
-		buffer_offset += len;
-		data_length -= len;
-		if (data_length > 0) return false;
-		if (parse_format()) {
-			//Serial.println("audio format ok");
-			p += len;
-			size -= len;
-			data_length = 8;
-			header_offset = 0;
-			state = STATE_PARSE3;
-			goto start;
-		}
-		//Serial.println("unknown audio format");
-		break;
+    // check & extract key audio parameters
+    case STATE_PARSE2:
+      len = data_length;
+      if (size < len) len = size;
+      memcpy((uint8_t *)header + header_offset, p, len);
+      header_offset += len;
+      buffer_offset += len;
+      data_length -= len;
+      if (data_length > 0) return false;
+      if (parse_format()) {
+        //Serial.println("audio format ok");
+        p += len;
+        size -= len;
+        data_length = 8;
+        header_offset = 0;
+        state = STATE_PARSE3;
+        goto start;
+      }
+      //Serial.println("unknown audio format");
+      break;
 
-	  // find the data chunk
-	  case STATE_PARSE3: // 10
-		len = data_length;
-		if (size < len) len = size;
-		memcpy((uint8_t *)header + header_offset, p, len);
-		header_offset += len;
-		buffer_offset += len;
-		data_length -= len;
-		if (data_length > 0) return false;
-		//Serial.print("chunk id = ");
-		//Serial.print(header[0], HEX);
-		//Serial.print(", length = ");
-		//Serial.println(header[1]);
-		p += len;
-		size -= len;
-		data_length = header[1];
-		if (header[0] == 0x61746164) {
-			//Serial.print("wav: found data chunk, len=");
-			//Serial.println(data_length);
-			// TODO: verify offset in file is an even number
-			// as required by WAV format.  abort if odd.  Code
-			// below will depend upon this and fail if not even.
-			leftover_bytes = 0;
-			state = state_play;
-			if (state & 1) {
-				// if we're going to start stereo
-				// better allocate another output block
-				block_right = allocate();
-				if (!block_right) return false;
-			}
-			total_length = data_length;
-		} else {
-			state = STATE_PARSE4;
-		}
-		goto start;
+    // find the data chunk
+    case STATE_PARSE3:  // 10
+      len = data_length;
+      if (size < len) len = size;
+      memcpy((uint8_t *)header + header_offset, p, len);
+      header_offset += len;
+      buffer_offset += len;
+      data_length -= len;
+      if (data_length > 0) return false;
+      //Serial.print("chunk id = ");
+      //Serial.print(header[0], HEX);
+      //Serial.print(", length = ");
+      //Serial.println(header[1]);
+      p += len;
+      size -= len;
+      data_length = header[1];
+      if (header[0] == 0x61746164) {
+        //Serial.print("wav: found data chunk, len=");
+        //Serial.println(data_length);
+        // TODO: verify offset in file is an even number
+        // as required by WAV format.  abort if odd.  Code
+        // below will depend upon this and fail if not even.
+        leftover_bytes = 0;
+        state = state_play;
+        if (state & 1) {
+          // if we're going to start stereo
+          // better allocate another output block
+          block_right = allocate();
+          if (!block_right) return false;
+        }
+        total_length = data_length;
+      } else {
+        state = STATE_PARSE4;
+      }
+      goto start;
 
-	  // ignore any extra unknown chunks (title & artist info)
-	  case STATE_PARSE4: // 11
-		if (size < data_length) {
-			data_length -= size;
-			buffer_offset += size;
-			return false;
-		}
-		p += data_length;
-		size -= data_length;
-		buffer_offset += data_length;
-		data_length = 8;
-		header_offset = 0;
-		state = STATE_PARSE3;
-		//Serial.println("consumed unknown chunk");
-		goto start;
+    // ignore any extra unknown chunks (title & artist info)
+    case STATE_PARSE4:  // 11
+      if (size < data_length) {
+        data_length -= size;
+        buffer_offset += size;
+        return false;
+      }
+      p += data_length;
+      size -= data_length;
+      buffer_offset += data_length;
+      data_length = 8;
+      header_offset = 0;
+      state = STATE_PARSE3;
+      //Serial.println("consumed unknown chunk");
+      goto start;
 
-	  // skip past "junk" data before "fmt " header
-	  case STATE_PARSE5:
-		len = data_length;
-		if (size < len) len = size;
-		buffer_offset += len;
-		data_length -= len;
-		if (data_length > 0) return false;
-		p += len;
-		size -= len;
-		data_length = 8;
-		state = STATE_PARSE1;
-		goto start;
+    // skip past "junk" data before "fmt " header
+    case STATE_PARSE5:
+      len = data_length;
+      if (size < len) len = size;
+      buffer_offset += len;
+      data_length -= len;
+      if (data_length > 0) return false;
+      p += len;
+      size -= len;
+      data_length = 8;
+      state = STATE_PARSE1;
+      goto start;
 
-	  // playing mono at native sample rate
-	  case STATE_DIRECT_8BIT_MONO:
-		return false;
+    // playing mono at native sample rate
+    case STATE_DIRECT_8BIT_MONO:
+      return false;
 
-	  // playing stereo at native sample rate
-	  case STATE_DIRECT_8BIT_STEREO:
-		return false;
+    // playing stereo at native sample rate
+    case STATE_DIRECT_8BIT_STEREO:
+      return false;
 
-	  // playing mono at native sample rate
-	  case STATE_DIRECT_16BIT_MONO:
-		if (size > data_length) size = data_length;
-		data_length -= size;
-		while (1) {
-			lsb = *p++;
-			msb = *p++;
-			size -= 2;
-			block_left->data[block_offset++] = (msb << 8) | lsb;
-			if (block_offset >= AUDIO_BLOCK_SAMPLES) {
-				transmit(block_left, 0);
-				transmit(block_left, 1);
-				release(block_left);
-				block_left = NULL;
-				data_length += size;
-				buffer_offset = p - buffer;
-				if (block_right) release(block_right);
-				if (data_length == 0) state = STATE_STOP;
-				return true;
-			}
-			if (size == 0) {
-				if (data_length == 0) break;
-				return false;
-			}
-		}
-		//Serial.println("end of file reached");
-		// end of file reached
-		if (block_offset > 0) {
-			// TODO: fill remainder of last block with zero and transmit
-		}
-		state = STATE_STOP;
-		return false;
+    // playing mono at native sample rate
+    case STATE_DIRECT_16BIT_MONO:
+      if (size > data_length) size = data_length;
+      data_length -= size;
+      while (1) {
+        lsb = *p++;
+        msb = *p++;
+        size -= 2;
+        block_left->data[block_offset++] = (msb << 8) | lsb;
+        if (block_offset >= AUDIO_BLOCK_SAMPLES) {
+          transmit(block_left, 0);
+          transmit(block_left, 1);
+          release(block_left);
+          block_left = NULL;
+          data_length += size;
+          buffer_offset = p - buffer;
+          if (block_right) release(block_right);
+          if (data_length == 0) state = STATE_STOP;
+          return true;
+        }
+        if (size == 0) {
+          if (data_length == 0) break;
+          return false;
+        }
+      }
+      //Serial.println("end of file reached");
+      // end of file reached
+      if (block_offset > 0) {
+        // TODO: fill remainder of last block with zero and transmit
+      }
+      state = STATE_STOP;
+      return false;
 
-	  // playing stereo at native sample rate
-	  case STATE_DIRECT_16BIT_STEREO:
-		if (size > data_length) size = data_length;
-		data_length -= size;
-		if (leftover_bytes) {
-			block_left->data[block_offset] = header[0];
-//PAH fix problem with left+right channels being swapped
-			leftover_bytes = 0;
-			goto right16;
-		}
-		while (1) {
-			lsb = *p++;
-			msb = *p++;
-			size -= 2;
-			if (size == 0) {
-				if (data_length == 0) break;
-				header[0] = (msb << 8) | lsb;
-				leftover_bytes = 2;
-				return false;
-			}
-			block_left->data[block_offset] = (msb << 8) | lsb;
-			right16:
-			lsb = *p++;
-			msb = *p++;
-			size -= 2;
-			block_right->data[block_offset++] = (msb << 8) | lsb;
-			if (block_offset >= AUDIO_BLOCK_SAMPLES) {
-				transmit(block_left, 0);
-				release(block_left);
-				block_left = NULL;
-				transmit(block_right, 1);
-				release(block_right);
-				block_right = NULL;
-				data_length += size;
-				buffer_offset = p - buffer;
-				if (data_length == 0) state = STATE_STOP;
-				return true;
-			}
-			if (size == 0) {
-				if (data_length == 0) break;
-				leftover_bytes = 0;
-				return false;
-			}
-		}
-		// end of file reached
-		if (block_offset > 0) {
-			// TODO: fill remainder of last block with zero and transmit
-		}
-		state = STATE_STOP;
-		return false;
+    // playing stereo at native sample rate
+    case STATE_DIRECT_16BIT_STEREO:
+      if (size > data_length) size = data_length;
+      data_length -= size;
+      if (leftover_bytes) {
+        block_left->data[block_offset] = header[0];
+        //PAH fix problem with left+right channels being swapped
+        leftover_bytes = 0;
+        goto right16;
+      }
+      while (1) {
+        lsb = *p++;
+        msb = *p++;
+        size -= 2;
+        if (size == 0) {
+          if (data_length == 0) break;
+          header[0] = (msb << 8) | lsb;
+          leftover_bytes = 2;
+          return false;
+        }
+        block_left->data[block_offset] = (msb << 8) | lsb;
+right16:
+        lsb = *p++;
+        msb = *p++;
+        size -= 2;
+        block_right->data[block_offset++] = (msb << 8) | lsb;
+        if (block_offset >= AUDIO_BLOCK_SAMPLES) {
+          transmit(block_left, 0);
+          release(block_left);
+          block_left = NULL;
+          transmit(block_right, 1);
+          release(block_right);
+          block_right = NULL;
+          data_length += size;
+          buffer_offset = p - buffer;
+          if (data_length == 0) state = STATE_STOP;
+          return true;
+        }
+        if (size == 0) {
+          if (data_length == 0) break;
+          leftover_bytes = 0;
+          return false;
+        }
+      }
+      // end of file reached
+      if (block_offset > 0) {
+        // TODO: fill remainder of last block with zero and transmit
+      }
+      state = STATE_STOP;
+      return false;
 
-	  // playing mono, converting sample rate
-	  case STATE_CONVERT_8BIT_MONO :
-		return false;
+    // playing mono, converting sample rate
+    case STATE_CONVERT_8BIT_MONO:
+      return false;
 
-	  // playing stereo, converting sample rate
-	  case STATE_CONVERT_8BIT_STEREO:
-		return false;
+    // playing stereo, converting sample rate
+    case STATE_CONVERT_8BIT_STEREO:
+      return false;
 
-	  // playing mono, converting sample rate
-	  case STATE_CONVERT_16BIT_MONO:
-		return false;
+    // playing mono, converting sample rate
+    case STATE_CONVERT_16BIT_MONO:
+      return false;
 
-	  // playing stereo, converting sample rate
-	  case STATE_CONVERT_16BIT_STEREO:
-		return false;
+    // playing stereo, converting sample rate
+    case STATE_CONVERT_16BIT_STEREO:
+      return false;
 
-	  // ignore any extra data after playing
-	  // or anything following any error
-	  case STATE_STOP:
-		return false;
+    // ignore any extra data after playing
+    // or anything following any error
+    case STATE_STOP:
+      return false;
 
-	  // this is not supposed to happen!
-	  //default:
-		//Serial.println("AudioPlaySdWav, unknown state");
-	}
-	state_play = STATE_STOP;
-	state = STATE_STOP;
-	return false;
+      // this is not supposed to happen!
+      //default:
+      //Serial.println("AudioPlaySdWav, unknown state");
+  }
+  state_play = STATE_STOP;
+  state = STATE_STOP;
+  return false;
 }
 
 
@@ -509,96 +504,92 @@ start:
 //  256 byte chunks, speed is 443272 bytes/sec
 //  512 byte chunks, speed is 468023 bytes/sec
 
-#define B2M_44100 (uint32_t)((double)4294967296000.0 / AUDIO_SAMPLE_RATE_EXACT) // 97352592
+#define B2M_44100 (uint32_t)((double)4294967296000.0 / AUDIO_SAMPLE_RATE_EXACT)  // 97352592
 #define B2M_22050 (uint32_t)((double)4294967296000.0 / AUDIO_SAMPLE_RATE_EXACT * 2.0)
 #define B2M_11025 (uint32_t)((double)4294967296000.0 / AUDIO_SAMPLE_RATE_EXACT * 4.0)
 
-bool AudioPlayUSBWav::parse_format(void)
-{
-	uint8_t num = 0;
-	uint16_t format;
-	uint16_t channels;
-	uint32_t rate, b2m;
-	uint16_t bits;
+bool AudioPlayUSBWav::parse_format(void) {
+  uint8_t num = 0;
+  uint16_t format;
+  uint16_t channels;
+  uint32_t rate, b2m;
+  uint16_t bits;
 
-	format = header[0];
-	//Serial.print("  format = ");
-	//Serial.println(format);
-	if (format != 1) return false;
+  format = header[0];
+  //Serial.print("  format = ");
+  //Serial.println(format);
+  if (format != 1) return false;
 
-	rate = header[1];
-	//Serial.print("  rate = ");
-	//Serial.println(rate);
-	if (rate == 44100) {
-		b2m = B2M_44100;
-	} else if (rate == 22050) {
-		b2m = B2M_22050;
-		num |= 4;
-	} else if (rate == 11025) {
-		b2m = B2M_11025;
-		num |= 4;
-	} else {
-		return false;
-	}
+  rate = header[1];
+  //Serial.print("  rate = ");
+  //Serial.println(rate);
+  if (rate == 44100) {
+    b2m = B2M_44100;
+  } else if (rate == 22050) {
+    b2m = B2M_22050;
+    num |= 4;
+  } else if (rate == 11025) {
+    b2m = B2M_11025;
+    num |= 4;
+  } else {
+    return false;
+  }
 
-	channels = header[0] >> 16;
-	//Serial.print("  channels = ");
-	//Serial.println(channels);
-	if (channels == 1) {
-	} else if (channels == 2) {
-		b2m >>= 1;
-		num |= 1;
-	} else {
-		return false;
-	}
+  channels = header[0] >> 16;
+  //Serial.print("  channels = ");
+  //Serial.println(channels);
+  if (channels == 1) {
+  } else if (channels == 2) {
+    b2m >>= 1;
+    num |= 1;
+  } else {
+    return false;
+  }
 
-	bits = header[3] >> 16;
-	//Serial.print("  bits = ");
-	//Serial.println(bits);
-	if (bits == 8) {
-	} else if (bits == 16) {
-		b2m >>= 1;
-		num |= 2;
-	} else {
-		return false;
-	}
+  bits = header[3] >> 16;
+  //Serial.print("  bits = ");
+  //Serial.println(bits);
+  if (bits == 8) {
+  } else if (bits == 16) {
+    b2m >>= 1;
+    num |= 2;
+  } else {
+    return false;
+  }
 
-	bytes2millis = b2m;
-	//Serial.print("  bytes2millis = ");
-	//Serial.println(b2m);
+  bytes2millis = b2m;
+  //Serial.print("  bytes2millis = ");
+  //Serial.println(b2m);
 
-	// we're not checking the byte rate and block align fields
-	// if they're not the expected values, all we could do is
-	// return false.  Do any real wav files have unexpected
-	// values in these other fields?
-	state_play = num;
-	return true;
+  // we're not checking the byte rate and block align fields
+  // if they're not the expected values, all we could do is
+  // return false.  Do any real wav files have unexpected
+  // values in these other fields?
+  state_play = num;
+  return true;
 }
 
 
-bool AudioPlayUSBWav::isPlaying(void)
-{
-	uint8_t s = *(volatile uint8_t *)&state;
-	return (s < 8);
+bool AudioPlayUSBWav::isPlaying(void) {
+  uint8_t s = *(volatile uint8_t *)&state;
+  return (s < 8);
 }
 
-uint32_t AudioPlayUSBWav::positionMillis(void)
-{
-	uint8_t s = *(volatile uint8_t *)&state;
-	if (s >= 8) return 0;
-	uint32_t tlength = *(volatile uint32_t *)&total_length;
-	uint32_t dlength = *(volatile uint32_t *)&data_length;
-	uint32_t offset = tlength - dlength;
-	uint32_t b2m = *(volatile uint32_t *)&bytes2millis;
-	return ((uint64_t)offset * b2m) >> 32;
+uint32_t AudioPlayUSBWav::positionMillis(void) {
+  uint8_t s = *(volatile uint8_t *)&state;
+  if (s >= 8) return 0;
+  uint32_t tlength = *(volatile uint32_t *)&total_length;
+  uint32_t dlength = *(volatile uint32_t *)&data_length;
+  uint32_t offset = tlength - dlength;
+  uint32_t b2m = *(volatile uint32_t *)&bytes2millis;
+  return ((uint64_t)offset * b2m) >> 32;
 }
 
 
-uint32_t AudioPlayUSBWav::lengthMillis(void)
-{
-	uint8_t s = *(volatile uint8_t *)&state;
-	if (s >= 8) return 0;
-	uint32_t tlength = *(volatile uint32_t *)&total_length;
-	uint32_t b2m = *(volatile uint32_t *)&bytes2millis;
-	return ((uint64_t)tlength * b2m) >> 32;
+uint32_t AudioPlayUSBWav::lengthMillis(void) {
+  uint8_t s = *(volatile uint8_t *)&state;
+  if (s >= 8) return 0;
+  uint32_t tlength = *(volatile uint32_t *)&total_length;
+  uint32_t b2m = *(volatile uint32_t *)&bytes2millis;
+  return ((uint64_t)tlength * b2m) >> 32;
 }

--- a/examples/Storage/WavFilePlayerUSB/play_usb_wav.h
+++ b/examples/Storage/WavFilePlayerUSB/play_usb_wav.h
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
- // Modified for use with USB mass storage drives 2020 Warren Watson
+// Modified for use with USB mass storage drives 2020 Warren Watson
 
 #ifndef play_usb_wav_h_
 #define play_usb_wav_h_
@@ -33,35 +33,37 @@
 #include "AudioStream.h"
 #include "FS.h"
 
-class AudioPlayUSBWav : public AudioStream
-{
+class AudioPlayUSBWav : public AudioStream {
 public:
-	AudioPlayUSBWav(void) : AudioStream(0, NULL), block_left(NULL), block_right(NULL) { begin(); }
-	void begin(void);
-	bool play(File *pfile);
-	void stop(void);
-	bool isPlaying(void);
-	uint32_t positionMillis(void);
-	uint32_t lengthMillis(void);
-	virtual void update(void);
+  AudioPlayUSBWav(void)
+    : AudioStream(0, NULL), block_left(NULL), block_right(NULL) {
+    begin();
+  }
+  void begin(void);
+  bool play(File *pfile);
+  void stop(void);
+  bool isPlaying(void);
+  uint32_t positionMillis(void);
+  uint32_t lengthMillis(void);
+  virtual void update(void);
 private:
-	File *wavfile;
-	bool consume(uint32_t size);
-	bool parse_format(void);
-	uint32_t header[10];		// temporary storage of wav header data
-	uint32_t data_length;		// number of bytes remaining in current section
-	uint32_t total_length;		// number of audio data bytes in file
-	uint32_t bytes2millis;
-	audio_block_t *block_left;
-	audio_block_t *block_right;
-	uint16_t block_offset;		// how much data is in block_left & block_right
-	uint8_t buffer[2048]__attribute__((aligned(0x4)));		// buffer one block of data
-	uint16_t buffer_offset;		// where we're at consuming "buffer"
-	uint16_t buffer_length;		// how much data is in "buffer" (512 until last read)
-	uint8_t header_offset;		// number of bytes in header[]
-	uint8_t state;
-	uint8_t state_play;
-	uint8_t leftover_bytes;
+  File *wavfile;
+  bool consume(uint32_t size);
+  bool parse_format(void);
+  uint32_t header[10];    // temporary storage of wav header data
+  uint32_t data_length;   // number of bytes remaining in current section
+  uint32_t total_length;  // number of audio data bytes in file
+  uint32_t bytes2millis;
+  audio_block_t *block_left;
+  audio_block_t *block_right;
+  uint16_t block_offset;                               // how much data is in block_left & block_right
+  uint8_t buffer[2048] __attribute__((aligned(0x4)));  // buffer one block of data
+  uint16_t buffer_offset;                              // where we're at consuming "buffer"
+  uint16_t buffer_length;                              // how much data is in "buffer" (512 until last read)
+  uint8_t header_offset;                               // number of bytes in header[]
+  uint8_t state;
+  uint8_t state_play;
+  uint8_t leftover_bytes;
 };
 
 #endif

--- a/examples/Storage/WavFilePlayerUSB/play_usb_wav.h
+++ b/examples/Storage/WavFilePlayerUSB/play_usb_wav.h
@@ -32,21 +32,20 @@
 #include "Arduino.h"
 #include "AudioStream.h"
 #include "FS.h"
-//#include <UsbMscFat.h>
 
 class AudioPlayUSBWav : public AudioStream
 {
 public:
 	AudioPlayUSBWav(void) : AudioStream(0, NULL), block_left(NULL), block_right(NULL) { begin(); }
 	void begin(void);
-	bool play(const char *filename);
+	bool play(File *pfile);
 	void stop(void);
 	bool isPlaying(void);
 	uint32_t positionMillis(void);
 	uint32_t lengthMillis(void);
 	virtual void update(void);
 private:
-	File wavfile;
+	File *wavfile;
 	bool consume(uint32_t size);
 	bool parse_format(void);
 	uint32_t header[10];		// temporary storage of wav header data


### PR DESCRIPTION
Fixes #102

Several of the examples were not updated to work with the now automatic enumeration of partitions code.

I removed a few more pieces of the old manual code and updated the examples to reflect this.

I also updated the wave player example to play all of the wave files in the root directory of the storage instead of some fixed named ones.

@pr8x @mjs513 @wwatson4506 

Hopefully did not mess anything up. Pretty straight forward. 
