### PR TITLE
Fix certain USB flash drive usage failures. 

### DIFF
--- a/MassStorageDriver.cpp
+++ b/MassStorageDriver.cpp
@@ -273,8 +273,11 @@ uint8_t USBDrive::mscInit(void) {
 		}
 		yield();
 	} while(!available());
-  
-	msReset();
+
+// Uncommenting "msReset()" will cause certain USB flash drives to fail to init or read/write.
+// Several SanDisk devices have been proven to fail.
+// Possibly due to clearing default power on settings.
+//	msReset(); 
 	// delay(500); // Not needed any more.
 	maxLUN = msGetMaxLun();
 

--- a/utility/msc.h
+++ b/utility/msc.h
@@ -72,8 +72,8 @@
 
 // These two defines are timeouts for detecting a connected drive
 // and waiting for it to be operational.
-#define MEDIA_READY_TIMEOUT	1000
-#define MSC_CONNECT_TIMEOUT 4000
+#define MEDIA_READY_TIMEOUT	5000 // 1000
+#define MSC_CONNECT_TIMEOUT	5000 // 4000
 
 // Command Block Wrapper Struct
 typedef struct


### PR DESCRIPTION
Found "msReset()" was causing certain USB flash drives to fail to initialize and/or read/write. Several SanDisk devices have been proven to fail because of this.This could possibly be due to clearing default power on settings. Commented out "msReset()". Also extended the two timeouts in "msc.h" to 5000ms each. Needed for some SSD drives and SD card readers.

