### PR TITLE
Update DriveInfo.ino

### DIFF
--- a/examples/Storage/DriveInfo/DriveInfo.ino
+++ b/examples/Storage/DriveInfo/DriveInfo.ino
@@ -80,7 +80,7 @@ void setup()
   Serial.println("\nWaiting for Drive to initialize...");
 
   // Wait for the drive to start.
-  while (!myDrive) {
+  while (!myFiles) {
     myusb.Task();
   }
 


### PR DESCRIPTION
Fix intermittent drive init failure.
Ran into a situation where a USB drive would fail to initialize properly. This  showed up in two files. driveInfo.ino in the USBHost_t36 library and in an example sketch of mine copyFileUSB.ino. The drive init portion in setup() was incorrect:

Serial.print("\nInitializing USB MSC drive...");
  // Wait for the drive to start.
  while (!myDrive) {
    myusb.Task();
  }
This waited for the drive to appear which it did. But sometimes the filesystem portion was not ready and any disk operation would fail. So changed it to:

Serial.print("\nWaiting for partition to...");

  while (!myFiles) {
    myusb.Task();
  }
Tested ok without issue.