### PR TITLE
Mark functions as properly pure virtual

### DIFF
--- a/USBHost_t36.h
+++ b/USBHost_t36.h
@@ -451,7 +451,7 @@ protected:
     //   device has its vid&pid, class/subclass fields initialized
     //   type is 0 for device level, 1 for interface level, 2 for IAD
     //   descriptors points to the specific descriptor data
-    virtual bool claim(Device_t *device, int type, const uint8_t *descriptors, uint32_t len);
+    virtual bool claim(Device_t *device, int type, const uint8_t *descriptors, uint32_t len) = 0;
 
     // When an unknown (not chapter 9) control transfer completes, this
     // function is called for all drivers bound to the device.  Return
@@ -476,7 +476,7 @@ protected:
     // code continuing to call its API.  However, pipes and transfers
     // are the handled by lower layers, so device drivers do not free
     // pipes they created or cancel transfers they had in progress.
-    virtual void disconnect();
+    virtual void disconnect() = 0;
 
     // Drivers are managed by this single-linked list.  All inactive
     // (not bound to any device) drivers are linked from


### PR DESCRIPTION
Not defining or marking a virtual function _pure virtual_ (`=0`) is actually UB in C++:

> C++03 Standard: 10.3 Virtual functions [class.virtual]
> 
> A virtual function declared in a class shall be defined, or declared pure (10.4) in that class, or both; but no diagnostic is required (3.2).

This was actually causing obscure linker issues in debug mode (see [here](https://forum.pjrc.com/threads/73333-DEBUG-undefined-reference-to-vtable-for-USBDriver))