### PR TITLE
Add Xbox Elite Series 1 and 2 PID to joystick.cpp

### DIFF
--- a/joystick.cpp
+++ b/joystick.cpp
@@ -62,6 +62,8 @@ JoystickController::product_vendor_mapping_t JoystickController::pid_vid_mapping
     { 0x045e, 0x02dd, XBOXONE, false },  // Xbox One Controller
     { 0x045e, 0x02ea, XBOXONE, false },  // Xbox One S Controller
     { 0x045e, 0x0b12, XBOXONE, false },  // Xbox Core Controller (Series S/X)
+    { 0x045e, 0x02e3, XBOXONE, false },  // Xbox Elite Series 1 Controller
+    { 0x045e, 0x0b00, XBOXONE, false },  // Xbox Elite Series 2 Controller
     { 0x045e, 0x0719, XBOX360, false},
     { 0x045e, 0x028E, SWITCH, false},  // Switch?
     { 0x057E, 0x2009, SWITCH, true},   // Switch Pro controller.  // Let the swtich grab it, but...


### PR DESCRIPTION
Tried USBHost examples and noticed that  Xbox Elite Series 1 would not work with provided example, investigated and found that VID and PID for  Xbox Elite Series 1 and 2 were not declared in the joystick.cpp file.