### PR TITLE
HID Joystick Hat and Extra Button Support

### DIFF
--- a/USBHost_t36.h
+++ b/USBHost_t36.h
@@ -1005,6 +1005,7 @@ public:
 
     // Returns the currently pressed buttons on the joystick
     uint32_t getButtons() { return buttons; }
+    uint32_t getExtraButtons() { return extra_buttons; }
 
     // Returns the HID Report ID
     uint8_t getReportID() { return report_id_;}
@@ -1013,8 +1014,7 @@ public:
     int     getAxis(uint32_t index) { return (index < (sizeof(axis) / sizeof(axis[0]))) ? axis[index] : 0; }
 
     // Return hat switch state
-    int32_t getHatSwitchRaw() { return hat_switch; }
-    int8_t getHatSwitchDirection() { return hat_direction; }
+    int8_t getHatSwitch() { return hat_switch; }
 
     // Retuns bit mask showing which axis are defined for the current joystick
     uint64_t axisMask() {return axis_mask_;}
@@ -1114,13 +1114,13 @@ private:
     bool anychange = false;
     volatile bool joystickEvent = false;
     uint32_t buttons = 0;
+    uint32_t extra_buttons = 0;
     int axis[TOTAL_AXIS_COUNT] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     uint64_t axis_mask_ = 0;    // which axis have valid data
     uint64_t axis_changed_mask_ = 0;
     uint64_t axis_change_notify_mask_ = 0x3ff;  // assume the low 10 values only.
 
-    int32_t hat_switch = -1;  // Raw hat switch value (-1 = centered, others map to direction)
-    int8_t hat_direction = -1; // Simplified direction (0 = up, 1 = up-right, etc.)
+    int8_t hat_switch = 0;
 
     uint16_t additional_axis_usage_page_ = 0;
     uint16_t additional_axis_usage_start_ = 0;

--- a/USBHost_t36.h
+++ b/USBHost_t36.h
@@ -1012,6 +1012,10 @@ public:
     // Returns the specified axis value
     int     getAxis(uint32_t index) { return (index < (sizeof(axis) / sizeof(axis[0]))) ? axis[index] : 0; }
 
+    // Return hat switch state
+    int32_t getHatSwitchRaw() { return hat_switch; }
+    int8_t getHatSwitchDirection() { return hat_direction; }
+
     // Retuns bit mask showing which axis are defined for the current joystick
     uint64_t axisMask() {return axis_mask_;}
 
@@ -1114,6 +1118,9 @@ private:
     uint64_t axis_mask_ = 0;    // which axis have valid data
     uint64_t axis_changed_mask_ = 0;
     uint64_t axis_change_notify_mask_ = 0x3ff;  // assume the low 10 values only.
+
+    int32_t hat_switch = -1;  // Raw hat switch value (-1 = centered, others map to direction)
+    int8_t hat_direction = -1; // Simplified direction (0 = up, 1 = up-right, etc.)
 
     uint16_t additional_axis_usage_page_ = 0;
     uint16_t additional_axis_usage_start_ = 0;

--- a/joystick.cpp
+++ b/joystick.cpp
@@ -666,7 +666,7 @@ void JoystickController::hid_input_data(uint32_t usage, int32_t value)
                 anychange = true;
             }
         }
-    } else if (usage_page == 1 && usage >= 0x30 && usage <= 0x39) {
+    } else if (usage_page == 1 && usage >= 0x30 && usage <= 0x38) {
         // TODO: need scaling of value to consistent API, 16 bit signed?
         // TODO: many joysticks repeat slider usage.  Detect & map to axis?
         uint32_t i = usage - 0x30;
@@ -696,6 +696,16 @@ void JoystickController::hid_input_data(uint32_t usage, int32_t value)
             //DBGPrintf("UB: index=%x value=%x\n", usage_index, value);
         }
 
+    } else if (usage_page == 1 && usage == 0x39) { // 0x39 is the hat switch usage
+        if (hat_switch != value) {
+            hat_switch = value; // Store the current value of the hat switch
+            anychange = true; // Indicate that something has changed
+
+            hat_direction = value;
+
+
+            DBGPrintf("Hat switch value changed: %d (mapped to direction: %d)\n", value, hat_direction);
+        }
     } else {
         DBGPrintf("UP: usage_page=%x usage=%x add: %x %x %d\n", usage_page, usage, additional_axis_usage_page_, additional_axis_usage_start_, additional_axis_usage_count_);
 


### PR DESCRIPTION
Provides a getHat() and getExtraButtons() method to the JoystickController for joysticks with more than 32 buttons without breaking current button implementation.